### PR TITLE
Fixes #73

### DIFF
--- a/lib/services/lwm2mHandlers/commonLwm2m.js
+++ b/lib/services/lwm2mHandlers/commonLwm2m.js
@@ -70,6 +70,41 @@ function activeDataHandler(registeredDevice, name, type, value) {
 }
 
 /**
+ * Given a registered device,a OMA Object and the corresponding active attribute, creates an observer for the resource 
+ * associated with that kind of device.
+ * 
+ * @param  {Object} registeredDevice
+ * @param  {Object} lwm2mMapping
+ * @param  {Object} activeAttribute
+ * @param  {Function} activeDataHandler
+ * @param  {Function} callback
+ */
+function observeActiveAttribute(registeredDevice, lwm2mMapping, activeAttribute, activeDataHandler, callback) {
+    lwm2mLib.observe(
+        registeredDevice.internalId,
+        lwm2mMapping.objectType,
+        lwm2mMapping.objectInstance,
+        lwm2mMapping.objectResource,
+        apply(activeDataHandler,
+            registeredDevice,
+            activeAttribute.name,
+            activeAttribute.type),
+        function(err, data) {
+            if (err) {
+                return callback(err);
+            } else {
+                activeDataHandler(
+                registeredDevice,
+                activeAttribute.name,
+                activeAttribute.type,
+                data);
+                return callback();
+            }
+        }
+    );
+}
+
+/**
  * Given a registered device and a text payload indicating a list of the OMA Objects supported by a client, creates an
  * observer for each active resource associated with that kind of device.
  *
@@ -115,16 +150,11 @@ function observeActiveAttributes(payload, registeredDevice, callback) {
 
             for (var j = 0; j < objects.length; j++) {
                 if (mappedUri === objects[j]) {
-                    observationList.push(apply(lwm2mLib.observe,
-                        registeredDevice.internalId,
-                        lwm2mMapping.objectType,
-                        lwm2mMapping.objectInstance,
-                        lwm2mMapping.objectResource,
-                        apply(activeDataHandler,
-                            registeredDevice,
-                            activeAttributes[i].name,
-                            activeAttributes[i].type)
-                    ));
+                    observationList.push(apply(observeActiveAttribute,
+                        registeredDevice,
+                        lwm2mMapping,
+                        activeAttributes[i],
+                        activeDataHandler));
                 }
             }
         }


### PR DESCRIPTION
[activeDataHandler](https://github.com/telefonicaid/lightweightm2m-iotagent/blob/master/lib/services/lwm2mHandlers/commonLwm2m.js#L123) is not called for the first observation since lwm2m-node-lib returns this value as part of the callback as it can be seen in https://github.com/telefonicaid/lwm2m-node-lib/blob/master/lib/services/server/informationReporting.js#117.

Therefore, this first value is not processed and forwarded to the CB.