### PR TITLE
Clarified North/South, removed anchors, added code highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You will find some  more general considerations about the LWM2M Mapping we are u
 In order to assign the proper configuration for each type of device, a mechanism to assign types to new arriving devices should be used. This mechanism is based on Prefixes for the registrarion URL. For each type configured in the `lwm2m` configuration section in the `config.js` config file, a url prefix has to be defined. Whenever a registration arrives to an url with that prefix, the device will be assigned the corresponding type.
 
 ## Mappings
-One of the features to provide through the IoT Agent is the mapping between the protocol specific names of the South Bound to the application-specific names in the North Bound. In the case of Lightweight M2M, this means to map two things:
+One of the features to provide through the IoT Agent is the mapping between the protocol specific names of the South Port traffic to the application-specific names in the North Port. In the case of Lightweight M2M, this means to map two things:
 * OMA Registry objects and resources from their URIs (e.g.: '') to their common names (e.g.: '').
 * Custom device objects to the names defined by the user.
 

--- a/config.js
+++ b/config.js
@@ -30,7 +30,7 @@ config.lwm2m = {
     ipProtocol: 'udp4',
     serverProtocol: 'udp4',
     /**
-     * When a LWM2M client has active attributes, the IOTA sends an observe instruction for each one, just after the
+     * When a LWM2M client has active attributes, the IoT Agent sends an observe instruction for each one, just after the
      * client registers. This may cause cause an error when the client takes too long to start listening, as the
      * observe requests may not reach its destiny. This timeout (ms) is used to give the client the opportunity to
      * create the listener before the server sends the requests.

--- a/docs/administrationGuide.md
+++ b/docs/administrationGuide.md
@@ -81,7 +81,7 @@ the listener before the server sends the requests.
 - **defaultType**: for the cases when no type can be assigned to a device (no pre-provision or path assignation of type), this type will be assigned by default. E.g.: 'Device'
 - **types**: for IOTAgents with multiple southbound paths, this attribute maps attribute types (defined either in the configuration file or by using the Device Configuration API) to southbound interfaces. E.g.:
 
-```json
+```
         {
             name: 'Light',
             url: '/light'

--- a/docs/administrationGuide.md
+++ b/docs/administrationGuide.md
@@ -4,13 +4,15 @@ OMA Lightweight M2M IoT Agent: Administration Guide
 
 * [Prerequisites](#prerequisites)
 * [Installation](#installation)
+* [Usage](#usage)
 * [Configuration](#configuration)
 * [Packaging](#packaging)
-* [Sanity checks](#sanity)
-* [Diagnosis procedures](#diagnosis)
+* [Sanity checks](#sanity-checks)
+* [Diagnosis procedures](#diagnosis-procedures)
 
 # Prerequisites
-The IOT Agent requires Node.js 0.10.x to work and uses NPM as its package manager. Most Linux distributions offer packages to install it. For other OS, you can find instructions to install Node.js [here](https://nodejs.org/).
+
+The IoT Agent requires Node.js 0.10.x to work and uses NPM as its package manager. Most Linux distributions offer packages to install it. For other OS, you can find instructions to install Node.js [here](https://nodejs.org/).
 
 NOTE: the current version of Node.js, 0.12.x has not been tested with the Agent, so we suggest to download and use the previous version (that process can be eased with utilities as `n` or  `nvm`).
 
@@ -33,15 +35,15 @@ yum localinstall --nogpg <rpm-file>
 ```
 
 ## Using Docker
-There are automatic builds of the development version of the IOTAgent published in Docker hub. In order to install using the docker version, just execute the following:
+There are automatic builds of the development version of the IoT Agent published in Docker hub. In order to install using the docker version, just execute the following:
 ```
 docker run --link orion:orion telefonicaiot/lightweightm2m-iotagent
 ```
-As you can see, the Lightweight M2M (as any other IOTA) requires a Context Broker to work. In order to link it, just use the option `--link` as shown in the example.
+As you can see, the Lightweight M2M (as any other IoT Agent) requires a Context Broker to work. In order to link it, just use the option `--link` as shown in the example.
 
 # Usage
 ## Github installation
-In order to execute the IOTAgent, just issue the following command from the root folder of the cloned project:
+In order to execute the IoT Agent, just issue the following command from the root folder of the cloned project:
 ```
 bin/lwm2mAgent.js [config file]
 ```
@@ -60,7 +62,7 @@ service iotagent-lwm2m stop
 In this mode, the log file is written in `/var/log/iotagent-lwm2m/iotagent-lwm2m.log`.
 
 # Configuration
-There are two ways to provide the IOT Agent with a configuration set: passing the name of a config file (related to the
+There are two ways to provide the IoT Agent with a configuration set: passing the name of a config file (related to the
 root folder of the project) or customise the example `config.js` in the root.
 
 The configuration file is divided in two sections: one standard section for the NGSI traffic North of the IoT Agent `ngsi`, and another
@@ -72,14 +74,14 @@ The latter configures the Lightweight M2M library used for communicating with th
 
 These are the specific LWM2M parameters that can be configured for the agent:
 
-- **logLevel**: level of logs for the IOTAgent specific information. E.g.: 'DEBUG'.
-- **port**: UDP port where the IOTAgent will be listening. E.g.: 60001.
-- **delayedObservationTimeout**: When a LWM2M client has active attributes, the IOTA sends an observe instruction for
+- **logLevel**: level of logs for the IoTAgent specific information. E.g.: 'DEBUG'.
+- **port**: UDP port where the IoT Agent will be listening. E.g.: 60001.
+- **delayedObservationTimeout**: When a LWM2M client has active attributes, the IoT Agent sends an observe instruction for
 each one, just after the client registers. This may cause cause an error when the client takes too long to start listening,
 as the observe requests may not reach its destiny. This timeout (ms) is used to give the client the opportunity to create
 the listener before the server sends the requests.
 - **defaultType**: for the cases when no type can be assigned to a device (no pre-provision or path assignation of type), this type will be assigned by default. E.g.: 'Device'
-- **types**: for IOTAgents with multiple southbound paths, this attribute maps attribute types (defined either in the configuration file or by using the Device Configuration API) to southbound interfaces. E.g.:
+- **types**: for IoT Agents with multiple southbound paths, this attribute maps attribute types (defined either in the configuration file or by using the Device Configuration API) to southbound interfaces. E.g.:
 
 ```
         {
@@ -183,7 +185,7 @@ A quick way to check if the service is working is to use the `status` command of
 ```
 service iotagent-lwm2m status
 ```
-This will tell you if the SO thinks the IOTA Service is up. Be aware that this is just a quick method based on PID checking,
+This will tell you if the SO thinks the IoT Agent Service is up. Be aware that this is just a quick method based on PID checking,
 that doesn't check the actual working Agent, just the existence of the process. Querying the administrative interface
 is always a stronger check.
 

--- a/docs/administrationGuide.md
+++ b/docs/administrationGuide.md
@@ -9,13 +9,13 @@ OMA Lightweight M2M IoT Agent: Administration Guide
 * [Sanity checks](#sanity)
 * [Diagnosis procedures](#diagnosis)
 
-# <a name="prerequisites"> Prerequisites </a>
-The IOT Agent requires Node.js 0.10.x to work and uses NPM as its package manager. Most Linux distributions offer packages to install it. For other OS, you can find instructions to install Node.js [here](https://nodejs.org/). 
+# Prerequisites
+The IOT Agent requires Node.js 0.10.x to work and uses NPM as its package manager. Most Linux distributions offer packages to install it. For other OS, you can find instructions to install Node.js [here](https://nodejs.org/).
 
 NOTE: the current version of Node.js, 0.12.x has not been tested with the Agent, so we suggest to download and use the previous version (that process can be eased with utilities as `n` or  `nvm`).
 
 
-# <a name="installation"> Installation </a>
+# Installation
 
 ## Cloning the Github repository
 Once the repository is cloned, from the root folder of the project execute:
@@ -24,7 +24,7 @@ npm install
 ```
 This will download the dependencies for the project, and let it ready to the execution.
 
-## Using the RPM 
+## Using the RPM
 To see how to generate the RPM, follow the instructions in [Packaging](#rpm).
 
 To install the RPM, use the YUM tool:
@@ -39,7 +39,7 @@ docker run --link orion:orion telefonicaiot/lightweightm2m-iotagent
 ```
 As you can see, the Lightweight M2M (as any other IOTA) requires a Context Broker to work. In order to link it, just use the option `--link` as shown in the example.
 
-# <a name="usage"> Usage </a>
+# Usage
 ## Github installation
 In order to execute the IOTAgent, just issue the following command from the root folder of the cloned project:
 ```
@@ -59,28 +59,29 @@ service iotagent-lwm2m stop
 
 In this mode, the log file is written in `/var/log/iotagent-lwm2m/iotagent-lwm2m.log`.
 
-# <a name="configuration"> Configuration </a>
-There are two ways to provide the IOT Agent with a configuration set: passing the name of a config file (related to the 
-root folder of the project) or customise the example `config.js` in the root. 
+# Configuration
+There are two ways to provide the IOT Agent with a configuration set: passing the name of a config file (related to the
+root folder of the project) or customise the example `config.js` in the root.
 
-The configuration file is divided in two sections: one standard section for the NGSI North bound `ngsi`, and another 
-one for the specific Lightweight M2M South bound, `lwm2m`. The former follows the same format described for the Node.js 
-IOT Agent Framework, described [here](https://github.com/telefonicaid/iotagent-node-lib#global-configuration).
+The configuration file is divided in two sections: one standard section for the NGSI traffic North of the IoT Agent `ngsi`, and another
+one for the specific Lightweight M2M traffic South of the IoT Agent, `lwm2m`. The former follows the same format described for the Node.js
+IoT Agent Framework, described [here](https://github.com/telefonicaid/iotagent-node-lib#global-configuration).
 
-The latter configures the Lightweight M2M library used for communicating with the devices, as described 
+The latter configures the Lightweight M2M library used for communicating with the devices, as described
 [here](https://github.com/telefonicaid/lwm2m-node-lib#-configuration) (`server` section).
 
 These are the specific LWM2M parameters that can be configured for the agent:
 
 - **logLevel**: level of logs for the IOTAgent specific information. E.g.: 'DEBUG'.
 - **port**: UDP port where the IOTAgent will be listening. E.g.: 60001.
-- **delayedObservationTimeout**: When a LWM2M client has active attributes, the IOTA sends an observe instruction for 
-each one, just after the client registers. This may cause cause an error when the client takes too long to start listening, 
-as the observe requests may not reach its destiny. This timeout (ms) is used to give the client the opportunity to create 
+- **delayedObservationTimeout**: When a LWM2M client has active attributes, the IOTA sends an observe instruction for
+each one, just after the client registers. This may cause cause an error when the client takes too long to start listening,
+as the observe requests may not reach its destiny. This timeout (ms) is used to give the client the opportunity to create
 the listener before the server sends the requests.
 - **defaultType**: for the cases when no type can be assigned to a device (no pre-provision or path assignation of type), this type will be assigned by default. E.g.: 'Device'
 - **types**: for IOTAgents with multiple southbound paths, this attribute maps attribute types (defined either in the configuration file or by using the Device Configuration API) to southbound interfaces. E.g.:
-```
+
+```json
         {
             name: 'Light',
             url: '/light'
@@ -95,7 +96,7 @@ the listener before the server sends the requests.
         }
 ```
 
-# <a name="packaging"> Packaging </a>
+# Packaging
 The only package type allowed is RPM. In order to execute the packaging scripts, the RPM Build Tools must be available
 in the system.
 
@@ -105,14 +106,14 @@ cd rpm
 ./create-rpm.sh <release-number> <version-number>
 ```
 Where `<version-number>` is the version (x.y.z) you want the package to have and `<release-number>` is an increasing
-number dependent on previous installations. 
+number dependent on previous installations.
 
-# <a name="sanity"> Sanity checks </a>
+# Sanity checks
 The Sanity Check Procedures are the steps that a System Administrator will take to verify that an installation is ready
-to be tested. This is therefore a preliminary set of tests to ensure that obvious or basic malfunctioning is fixed 
+to be tested. This is therefore a preliminary set of tests to ensure that obvious or basic malfunctioning is fixed
 before proceeding to unit tests, integration tests and user validation
 
-## Checking the administrative interface is up 
+## Checking the administrative interface is up
 The first procedure that can be executed to check if the IoTAgent is running is to get the version from the administrative
 interface. A curl command can be used to do so:
 ```
@@ -128,12 +129,13 @@ Content-Length: 46
 ETag: W/"2e-d494dc75"
 Date: Fri, 25 Sep 2015 08:14:45 GMT
 Connection: keep-alive
- 
+
 {"version":"0.8.1","port":4041,"baseRoot":"/"}
 ```
 
 ## List of running processes
 The Agent runs a single node.js process, executing the `bin/lwm2mAgent.js` script. Here is an example of the runnig process.
+
 ```
 root       732 31786  8 10:14 pts/0    00:00:00 node bin/lwm2mAgent.js
 ```
@@ -142,32 +144,35 @@ If the process is running as a service, the PID number can be found in the `/opt
 ## Databases
 The Lightweight M2M can work with in-memory databases (for testing purposes) or with MongoDB, depending on the selected
 configuration. The host, port and database name are configured in the config file as well. Check the [Configuration](configuration)
-section for details. Be aware that both the North Bound and the South Bound make use of the DB, and that their configurations
+section for details. Be aware that the North Port and the South Port interactions both make use of the DB, and that their configurations
 can differ.
 
 ## Network Interfaces Up & Open
-Using `netstat` in a Linux machine, the ports can be checked up. The IoT Agent should be listening in two ports: the 
-administration and provisioning port (tipically TCP 4041) and the Lightweight M2M port (typically 60001). 
+Using `netstat` in a Linux machine, the ports can be checked up. The IoT Agent should be listening in two ports: the
+administration and provisioning port (tipically TCP 4041) and the Lightweight M2M port (typically 60001).
 
 The administrative port can be checked with the following command:
-```
+
+```bash
 netstat -ntpl | grep 4041
 ```
 
 and the result should be a single line like the following:
 
 ```
-tcp        0      0 0.0.0.0:4041                0.0.0.0:*                   LISTEN      <PID>/node            
+tcp        0      0 0.0.0.0:4041                0.0.0.0:*                   LISTEN      <PID>/node
 ```
 where the `<PID>` corresponds to the PID of the IoT Agent.
 
 
 The Lightweight M2M port can be checked with the following command:
-```
+
+```bash
 netstat -nupl | grep 60001
 ```
 
 and the expected result would be a line like the following:
+
 ```
 udp        0      0 0.0.0.0:60001               0.0.0.0:*                               589/node
 ```
@@ -178,7 +183,7 @@ A quick way to check if the service is working is to use the `status` command of
 ```
 service iotagent-lwm2m status
 ```
-This will tell you if the SO thinks the IOTA Service is up. Be aware that this is just a quick method based on PID checking, 
+This will tell you if the SO thinks the IOTA Service is up. Be aware that this is just a quick method based on PID checking,
 that doesn't check the actual working Agent, just the existence of the process. Querying the administrative interface
 is always a stronger check.
 
@@ -189,12 +194,12 @@ This library contains a simple command line Lightweight M2M Client that can be u
 on how to perform these kind of tests, see the How-To's in the [Getting Started section of the User Manual](userGuide.md#gettingstarted)
 that shows simple registrations and send measure tests.
 
-# <a name="diagnosis"> Diagnosis procedures </a>
+# Diagnosis procedures
 Whenever a problem is risen in the IoT Agent, or if the Sanity Checks fail, the administrator should look at the log files
-in order to check what kind of problema has happened. If the IoT Agent has been deployed using the RPMs, logs will be 
-located in the `/var/log/iotagent-lwm2m` folder. If the IoT Agent has been started from the command line, logs are 
+in order to check what kind of problema has happened. If the IoT Agent has been deployed using the RPMs, logs will be
+located in the `/var/log/iotagent-lwm2m` folder. If the IoT Agent has been started from the command line, logs are
 written to the stdout. Whenever you are trying to debug a log, change first the log level as explained in the configuration
-section. Be aware that the northbound and southbound sides of the IOTA have different log levels, that can be set independently.
+section. Be aware that the North Port and South Port interactions of the IoT Agent have different log levels, that can be set independently.
 
 ## Resource availability
 To be filled soon by DevOps.
@@ -212,6 +217,6 @@ is reproduced here, for clarity:
 ![General ](https://raw.githubusercontent.com/telefonicaid/iotagent-node-lib/master/img/ngsiInteractions.png "NGSI Interactions")
 
 The interaction in the South Bound follows the flows defined by the [OMA Lightweight M2M Specification](http://openmobilealliance.org/about-oma/work-program/m2m-enablers/).
- 
+
 
 

--- a/docs/configurationProvisioning.md
+++ b/docs/configurationProvisioning.md
@@ -1,10 +1,11 @@
 Configuration Provisioning guide
 ==================
 # Index
+
 * [Overview](#overview)
-* [Installation](#overview)
-* [Configuration](#overview)
-* [Usage](#overview)
+* [Installation](#installation)
+* [Configuration](#configuration)
+* [Usage](#usage)
 
 
 # Overview

--- a/docs/configurationProvisioning.md
+++ b/docs/configurationProvisioning.md
@@ -7,8 +7,8 @@ Configuration Provisioning guide
 * [Usage](#overview)
 
 
-# <a name="overview"> Overview </a>
-This guide will show the process of using the IoT Agent with configuration provisioning. In this use case, the owner 
+# Overview
+This guide will show the process of using the IoT Agent with configuration provisioning. In this use case, the owner
 of the devices, before connecting each one of them, provisions a device configuration that will be shared among all the devices
 of the same type. The pieces of information that will be used to distinguish between devices will be the `resource` and
 the API key.
@@ -16,11 +16,11 @@ the API key.
 This guide will use a Lightweight M2M client to simulate the interaction with the device. The installation and use of
 this client will be explained when appropriate.
 
-This guide will make use of the automatic OMA Registry mapping, with the example of the `WeatherBaloon` defined in the
+This guide will make use of the automatic OMA Registry mapping, with the example of the `WeatherBalloon` defined in the
 [Getting Started](userGuide.md#gettingstarted) section. So, the attributes will be defined exclusively by their name, and the mapping
 from and to a full LWM2M Mapping (like /387/3/23) will be performed by the IoT Agent.
 
-# <a name="installation"> Installation </a>
+# Installation
 ## Installation of the Agent
 In order to install the agent, first of all, clone the Github repository:
 ```
@@ -42,53 +42,57 @@ And download the dependencies, executing, from the root folder of the project:
 npm install
 ```
 
-# <a name="configuration"> Configuration </a>
-Most of the the default `config.js` file coming with the repository should meet your needs for this guide, but there 
+# Configuration
+Most of the the default `config.js` file coming with the repository should meet your needs for this guide, but there
 are two attributes that you will want to tailor:
 
 - *config.ngsi.contextBroker.host*: host IP for the ContextBroker you will be using with the IoT Agent.
 - *config.ngsi.providerUrl*: url where your IoT Agent will be listening for ContextProvider requests. Usually this will
-be your machine's IP and the default port, but in case you are using an external context broker (or one deployed in 
+be your machine's IP and the default port, but in case you are using an external context broker (or one deployed in
 a Virtual Machine) it may differ.
 
 
-You should change at least the log level to `DEBUG`, as in other levels it will not show information of 
+You should change at least the log level to `DEBUG`, as in other levels it will not show information of
 what's going on with the execution.
 
-# <a name="usage"> Usage </a>
+# Usage
 
 ## Start the agent
 In order to start the agent, from the root folder of the repository type:
-```
+
+```bash
 bin/lwm2mAgent.js
 ```
+
 This will execute the IoT Agent in the foreground, so you can see the logs of what's happening.
 
 With the agent still open, in other terminal, open the Client, typing the following command from the client's root
 folder
-```
+
+```bash
 bin/iotagent-lwm2m-client.js
 ```
 
 ## Provisioning the configuration
 Before starting to use any device a device configuration should be created. In this step we will create a configuration
-for all the devices of type 'WeatherBaloon'. To send the configuration creation request we will be using the `curl` command 
+for all the devices of type 'WeatherBalloon'. To send the configuration creation request we will be using the `curl` command
 that comes installed with any Unix-like OS.
- 
-This request has to be sent to the administrative port of the IoT Agent (default value 4041), not to the
-Lightweight M2M port. 
 
-The following request creates the configuration group for devices with type `WeatherBaloon`:
-```
+This request has to be sent to the administrative port of the IoT Agent (default value 4041), not to the
+Lightweight M2M port.
+
+The following request creates the configuration group for devices with type `WeatherBalloon`:
+
+```bash
 (curl localhost:4041/iot/services -s -S --header 'Content-Type: application/json' \
-  --header 'Accept: application/json' --header 'fiware-service: weather' --header 'fiware-servicepath: /baloons' \
+  --header 'Accept: application/json' --header 'fiware-service: weather' --header 'fiware-servicepath: /balloons' \
   -d @- | python -mjson.tool) <<EOF
 {
   "services": [
     {
-      "resource": "/weatherBaloon",
+      "resource": "/weatherBalloon",
       "apikey": "",
-      "type": "WeatherBaloon",
+      "type": "WeatherBalloon",
       "commands": [],
       "lazy": [
         {
@@ -117,48 +121,58 @@ EOF
 ```
 
 ## Using the device
-In order to use the device, change to the terminal where the client has been started. 
+In order to use the device, change to the terminal where the client has been started.
 
 ### Creation of the objects in the client
 The first thing we should do before connecting to a LWM2M Server is to create the objects that the client will be serving.
-The reason to perform this step before any other (specially before the registration) is that, during the registration of 
+The reason to perform this step before any other (specially before the registration) is that, during the registration of
 the client, it will send to the server a list of all its available objects, so the server can subscribe to those resources
 configured by the client as active.
 
 From the client console, type the following commands:
-```
+
+```bash
 LWM2M-Client> create /6/0
 LWM2M-Client> create /3303/0
 LWM2M-Client> create /3312/0
 ```
+
 Once the object is created, give a default value for each of the attributes:
 
 * Longitude attribute:
-```
+
+```bash
 LWM2M-Client> set /6/0 0 12
 ```
+
 * Longitude attribute:
-```
+
+```bash
 LWM2M-Client> set /6/0 1 -4
 ```
+
 * Temperature attribute:
-```
+
+```bash
 LWM2M-Client> set /3303/0 0 23
 ```
 * Power attribute:
-```
+
+```bash
 LWM2M-Client> set /3312/0 0 On
 ```
 
 ### Connection to the server
 Once all the objects are created in the device, connect with the server with the following command:
+
+```bash
+LWM2M-Client> connect localhost 5684 weather1 /weatherBalloon
 ```
-LWM2M-Client> connect localhost 5684 weather1 /weatherBaloon
-```
+
 A few notes about this command:
 * First of all, the *endpoint name* used, `weather1`, can be whatever ID available; the type of device and its features
 will not be determined based on its Device ID, but based on the resource it is accessing.
-* The URL is `/weatherBaloon` the same one we used in the previous step, in the Configuration provisioning.
+* The URL is `/weatherBalloon` the same one we used in the previous step, in the Configuration provisioning.
 
 The following information should be presented in the client's console:
 ```
@@ -166,28 +180,29 @@ Connected:
 --------------------------------
 Device location: rd/2
 ```
-This indicates that the server has accepted the connection request and assigned the `rd/2` location for the client's 
+This indicates that the server has accepted the connection request and assigned the `rd/2` location for the client's
 requests. This exact location may change from device to device (every device has a unique location).
 
 If you configured the server in `DEBUG` mode, check the standard output to see what happened with the client registration.
 
 Now you should be able to see the Entity in your Context Broker. You can do that, querying any of the lazy attributes
 with the following command:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
- --header 'Accept: application/json' --header 'fiware-service: weather' --header 'fiware-servicepath: /baloons' \
+ --header 'Accept: application/json' --header 'fiware-service: weather' --header 'fiware-servicepath: /balloons' \
  -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
         {
-            "type": "WeatherBaloon",
+            "type": "WeatherBalloon",
             "isPattern": "false",
-            "id": "weather1:WeatherBaloon"
+            "id": "weather1:WeatherBalloon"
         }
     ],
     "attributes" : [
         "Latitude"
-    ]    
+    ]
 }
 EOF
 ```

--- a/docs/deviceProvisioning.md
+++ b/docs/deviceProvisioning.md
@@ -6,19 +6,19 @@ Device Provisioning Guide
 * [Configuration](#overview)
 * [Usage](#overview)
 
-# <a name="overview"> Overview </a>
+# Overview
 This guide will show the process of using the IoT Agent with device preprovisioning. In this use case, the owner of the
 devices, before connecting each device, will provision the device information into the agent. Then, the device can register
-itself in the server and start being used with the agent. 
+itself in the server and start being used with the agent.
 
 This guide will use a Lightweight M2M client to simulate the interaction with the device. The installation and use of
 this client will be explained when appropriate.
 
 In this guide we will provide an explicit mapping for all the device attributes, using the `Robot` example given in the
-[Getting Started](gettingStarted.md) section. Some of them could be mapped automatically using the OMA Registry 
+[Getting Started](gettingStarted.md) section. Some of them could be mapped automatically using the OMA Registry
 automatic mapping (but those will be covered in other step-by-step guides).
 
-# <a name="installation"> Installation </a>
+# Installation
 ## Installation of the Agent
 In order to install the agent, first of all, clone the Github repository:
 ```
@@ -40,42 +40,45 @@ And download the dependencies, executing, from the root folder of the project:
 npm install
 ```
 
-# <a name="configuration"> Configuration </a>
-Most of the the default `config.js` file coming with the repository should meet your needs for this guide, but there 
+# Configuration
+Most of the the default `config.js` file coming with the repository should meet your needs for this guide, but there
 are two attributes that you will want to tailor:
 
 - *config.ngsi.contextBroker.host*: host IP for the ContextBroker you will be using with the IoT Agent.
 - *config.ngsi.providerUrl*: url where your IoT Agent will be listening for ContextProvider requests. Usually this will
-be your machine's IP and the default port, but in case you are using an external context broker (or one deployed in 
+be your machine's IP and the default port, but in case you are using an external context broker (or one deployed in
 a Virtual Machine) it may differ.
 
-You should change at least the log level to `DEBUG`, as in other levels it will not show information of 
+You should change at least the log level to `DEBUG`, as in other levels it will not show information of
 what's going on with the execution.
 
-# <a name="usage"> Usage </a>
+# Usage
 ## Start the agent
 In order to start the agent, from the root folder of the repository type:
-```
+
+```bash
 bin/lwm2mAgent.js examples/config-factory.js
 ```
 This will execute the IoT Agent in the foreground, so you can see the logs of what's happening.
 
 With the agent still open, in other terminal, open the Client, typing the following command from the client's root
 folder
-```
+
+```bash
 bin/iotagent-lwm2m-client.js
 ```
 
 ## Provisioning the device
-Before starting to use any device, the device must be provisioned. In this step, we'll be sending a preprovisioning 
-request for a 'Robot' device. To send the preprovisioning request we will be using the `curl` command that comes installed 
+Before starting to use any device, the device must be provisioned. In this step, we'll be sending a preprovisioning
+request for a 'Robot' device. To send the preprovisioning request we will be using the `curl` command that comes installed
 with any Unix-like OS.
 
 This request has to be sent to the administrative port of the IoT Agent (default value 4041), not to the
-Lightweight M2M port. 
+Lightweight M2M port.
 
 The following request provision the device with device ID `robot1`:
-```
+
+```bash
 (curl localhost:4041/iot/devices -s -S --header 'Content-Type: application/json' \
   --header 'Accept: application/json' --header 'fiware-service: factory' --header 'fiware-servicepath: /robots' \
   -d @- | python -mjson.tool) <<EOF
@@ -126,40 +129,47 @@ The following request provision the device with device ID `robot1`:
 }
 EOF
 ```
+
 ## Using the device
-In order to use the device, change to the terminal where the client has been started. 
+In order to use the device, change to the terminal where the client has been started.
 
 ### Creation of the objects in the client
 The first thing we should do before connecting to a LWM2M Server is to create the objects that the client will be serving.
-The reason to perform this step before any other (specially before the registration) is that, during the registration of 
+The reason to perform this step before any other (specially before the registration) is that, during the registration of
 the client, it will send to the server a list of all its available objects, so the server can subscribe to those resources
 configured by the client as active.
 
 From the client console, type the following commands:
-```
+
+```bash
 LWM2M-Client> create /7392/0
 ```
 Once the object is created, give a default value for each of the attributes:
 * Battery attribute:
-```
+
+```bash
 LWM2M-Client> set /7392/0 1 89
 ```
 * Message attribute:
-```
+
+```bash
 LWM2M-Client> set /7392/0 2 "First robot here"
 ```
 * Position attribute:
-```
+
+```bash
 LWM2M-Client> set /7392/0 3 "[0, 0]"
 ```
 
 ### Connection to the server
 Once all the objects are created in the device, connect with the server with the following command:
-```
+
+```bash
 LWM2M-Client> connect localhost 5684 robot1 /
 ```
+
 A few notes about this command:
-* First of all, note that the *endpoint name* used, `robot1`, is the same we provisioned in advance with the provisioning 
+* First of all, note that the *endpoint name* used, `robot1`, is the same we provisioned in advance with the provisioning
 request.
 * Note the url used is `/`. This is the default URL and should be used for those devices that are not part of a specific
 configuration. For examples in how to use configuration, check the [Configuration Provisioning Guide](configurationProvisioning.md).
@@ -170,13 +180,14 @@ Connected:
 --------------------------------
 Device location: rd/1
 ```
-This indicates that the server has accepted the connection request and assigned the `rd/1` location for the client's 
+This indicates that the server has accepted the connection request and assigned the `rd/1` location for the client's
 requests. This exact location may change from device to device (every device has a unique location).
 
 If you configured the server in `DEBUG` mode, check the standard output to see what happened with the client registration.
 
 Now you should be able to see the Entity in your Context Broker. You can do that with the following command:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
  --header 'Accept: application/json' --header 'fiware-service: factory' --header 'fiware-servicepath: /robots' \
  -d @- | python -mjson.tool) <<EOF
@@ -191,22 +202,26 @@ Now you should be able to see the Entity in your Context Broker. You can do that
 }
 EOF
 ```
-Note that the headers of the request to the Context Broker should match the ones you used in the Device Provisioning. 
-Another thing to note is the Entity ID: it is formed by the concatenation of the type and the Device ID, separated by a colon. 
+
+Note that the headers of the request to the Context Broker should match the ones you used in the Device Provisioning.
+Another thing to note is the Entity ID: it is formed by the concatenation of the type and the Device ID, separated by a colon.
 This convention can be overriden in the provisioning request.
 
 ### Updating the active attributes
 In order to update the value of an attribute, issue a new `set` command, like the following:
-```
+
+```bash
 LWM2M-Client> set /7392/0 1 67
 ```
-This should trigger an update to the Context Broker information. A new request for the stored information in the Context 
+
+This should trigger an update to the Context Broker information. A new request for the stored information in the Context
 Broker should show the update.
 
 ### Reading lazy attributes
 In order to read the lazy attributes, just make a query to the entity specifying the attribute you want to read, as in
 the following case:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
  --header 'Accept: application/json' --header 'fiware-service: factory' --header 'fiware-servicepath: /robots' \
  -d @- | python -mjson.tool) <<EOF
@@ -228,7 +243,8 @@ EOF
 ### Sending a command to the device
 Sending commands to a device works much the same as the updating of lazy attributes. In order to send a new command,
 just update the command attribute in the Context Broker entity, with the following command:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
  --header 'Accept: application/json' --header 'fiware-service: factory' --header 'fiware-servicepath: /robots' \
  -d @- | python -mjson.tool) <<EOF

--- a/docs/staticConfiguration.md
+++ b/docs/staticConfiguration.md
@@ -2,9 +2,9 @@ Static Configuration Guide
 ==================
 # Index
 * [Overview](#overview)
-* [Installation](#overview)
-* [Configuration](#overview)
-* [Usage](#overview)
+* [Installation](#installation)
+* [Configuration](#configuration)
+* [Usage](#usage)
 
 # Overview
 This guide will show the process of using the IoT Agent with a static configuration. In this use case, the owner of the

--- a/docs/staticConfiguration.md
+++ b/docs/staticConfiguration.md
@@ -6,7 +6,7 @@ Static Configuration Guide
 * [Configuration](#overview)
 * [Usage](#overview)
 
-# <a name="overview"> Overview </a>
+# Overview
 This guide will show the process of using the IoT Agent with a static configuration. In this use case, the owner of the
 devices, before connecting each device, will create a static configuration for each device type. When a device is registered,
 it will be assigned to one of the configured types, from where it will obtain all its configuration data.
@@ -15,47 +15,53 @@ This guide will use a Lightweight M2M client to simulate the interaction with th
 this client will be explained when appropriate.
 
 In this guide we will provide an explicit mapping for all the device attributes, using the `Robot` example given in the
-[Getting Started](userGuide.md#gettingstarted) section. Some of them could be mapped automatically using the OMA Registry 
+[Getting Started](userGuide.md#gettingstarted) section. Some of them could be mapped automatically using the OMA Registry
 automatic mapping (but those will be covered in other step-by-step guides).
 
-# <a name="installation"> Installation </a>
+# Installation
 ## Installation of the Agent
 In order to install the agent, first of all, clone the Github repository:
-```
+
+```bash
 git clone https://github.com/telefonicaid/lightweightm2m-iotagent.git
 ```
 Once the repository is cloned, download the dependencies executing the following command from the root folder of the
 project:
-```
+
+```bash
 npm install
 ```
 
 ## Installation of the Client
 In order to install the client, clone the following Github repository:
-```
+
+```bash
 git clone https://github.com/telefonicaid/lwm2m-node-lib.git
 ```
+
 And download the dependencies, executing, from the root folder of the project:
-```
+
+```bash
 npm install
 ```
 
-# <a name="configuration"> Configuration </a>
+# Configuration
 In order to create the new configuration, backup the default `config.js` file and edit it with your new changes.
 
 There are two groups of data that should be changed in the configuration in order for this example to work. First of all,
-in order to connect the IoT Agent to the appropriate instance of the Context Broker, you should edit the following 
+in order to connect the IoT Agent to the appropriate instance of the Context Broker, you should edit the following
 attributes:
 
 * *config.ngsi.contextBroker.host*: host IP for the ContextBroker you will be using with the IoT Agent.
 * *config.ngsi.providerUrl*: url where your IoT Agent will be listening for ContextProvider requests. Usually this will
-be your machine's IP and the default port, but in case you are using an external context broker (or one deployed in 
+be your machine's IP and the default port, but in case you are using an external context broker (or one deployed in
 a Virtual Machine) it may differ.
 
 Once you have configured the connection information for the Context Broker, you must configure the information about the
 device types you have in your system. Two attributes will have to be changed in order to acomplish this step:
 * `config.lwm2m.types`: an entry should be added to this array with information on how to map URLs to types. Edit the config
 file adding that information, as shown in the example:
+
 ```
 config.lwm2m = {
 
@@ -72,11 +78,12 @@ config.lwm2m = {
 * `config.ngsi.types`: an entry should be added to this array with all the information about the type that is going to
 be configured. This information will include an *ad-hoc* mapping for the attribute names to LWM2M URIs. Edit the config
 file, as shown in the example:
+
 ```
 config.ngsi = {
-    
+
     [...]
-    
+
     types: {
         'Robot': {
             service: 'Factory',
@@ -85,13 +92,13 @@ config.ngsi = {
               {
                 "name": "Position",
                 "type": "location"
-              }            
+              }
             ],
             lazy: [
               {
                 "name": "Message",
                 "type": "string"
-              }            
+              }
             ],
             attributes: [
               {
@@ -118,24 +125,26 @@ config.ngsi = {
             }
         }
     },
-    
+
     [...]
 };
 ```
 
 You may need to change at least the log level to `DEBUG` to show information of what's going on with the execution.
 
-# <a name="usage"> Usage </a>
+# Usage
 ## Start the agent
 In order to start the agent, from the root folder of the repository type:
-```
+
+```bash
 bin/lwm2mAgent.js
 ```
 This will execute the IoT Agent in the foreground, so you can see the logs of what's happening.
 
 With the agent still open, in other terminal, open the Client, typing the following command from the client's root
 folder
-```
+
+```bash
 bin/iotagent-lwm2m-client.js
 ```
 
@@ -144,39 +153,48 @@ In this case, all the information that was needed in order to work with the Agen
 static configuration file, so there is no need for provisioning of neither devices nor configurations.
 
 ## Using the device
-In order to use the device, change to the terminal where the client has been started. 
+In order to use the device, change to the terminal where the client has been started.
 
 ### Creation of the objects in the client
 The first thing we should do before connecting to a LWM2M Server is to create the objects that the client will be serving.
-The reason to perform this step before any other (specially before the registration) is that, during the registration of 
+The reason to perform this step before any other (specially before the registration) is that, during the registration of
 the client, it will send to the server a list of all its available objects, so the server can subscribe to those resources
 configured by the client as active.
 
 From the client console, type the following commands:
-```
+
+```bash
 LWM2M-Client> create /7392/0
 ```
+
 Once the object is created, give a default value for each of the attributes:
 * Battery attribute:
-```
+
+```bash
 LWM2M-Client> set /7392/0 1 89
 ```
+
 * Message attribute:
-```
+
+```bash
 LWM2M-Client> set /7392/0 2 "First robot here"
 ```
+
 * Position attribute:
-```
+
+```bash
 LWM2M-Client> set /7392/0 3 "[0, 0]"
 ```
 
 ### Connection to the server
 Once all the objects are created in the device, connect with the server with the following command:
-```
+
+```bash
 LWM2M-Client> connect localhost 5684 robot1 /robots
 ```
+
 A few notes about this command:
-* First of all, note that the *endpoint name* used, `robot1`, is the same we provisioned in advance with the provisioning 
+* First of all, note that the *endpoint name* used, `robot1`, is the same we provisioned in advance with the provisioning
 request.
 * Note the url used is `/robots`. This is the URL we configured in the `config.lwm2m.types` attribute.
 
@@ -186,13 +204,14 @@ Connected:
 --------------------------------
 Device location: rd/2
 ```
-This indicates that the server has accepted the connection request and assigned the `rd/2` location for the client's 
+This indicates that the server has accepted the connection request and assigned the `rd/2` location for the client's
 requests. This exact location may change from device to device (every device has a unique location).
 
 If you configured the server in `DEBUG` mode, check the standard output to see what happened with the client registration.
 
 Now you should be able to see the Entity in your Context Broker. You can do that with the following command:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
  --header 'Accept: application/json' --header 'fiware-service: Factory' --header 'fiware-servicepath: /robots' \
  -d @- | python -mjson.tool) <<EOF
@@ -211,16 +230,19 @@ Note that the headers of the request to the Context Broker should match the ones
 
 ### Updating the active attributes
 In order to update the value of an attribute, issue a new `set` command, like the following:
-```
+
+```bash
 LWM2M-Client> set /7392/0 1 67
 ```
-This should trigger an update to the Context Broker information. A new request for the stored information in the Context 
+
+This should trigger an update to the Context Broker information. A new request for the stored information in the Context
 Broker should show the update.
 
 ### Reading lazy attributes
 In order to read the lazy attributes, just make a query to the entity specifying the attribute you want to read, as in
 the following case:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
  --header 'Accept: application/json' --header 'fiware-service: Factory' --header 'fiware-servicepath: /robots' \
  -d @- | python -mjson.tool) <<EOF
@@ -242,7 +264,8 @@ EOF
 ### Sending a command to the device
 Sending commands to a device works much the same as the updating of lazy attributes. In order to send a new command,
 just update the command attribute in the Context Broker entity, with the following command:
-```
+
+```bash
 (curl http://192.168.56.101:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
  --header 'Accept: application/json' --header 'fiware-service: Factory' --header 'fiware-servicepath: /robots' \
  -d @- | python -mjson.tool) <<EOF

--- a/docs/userGuide.md
+++ b/docs/userGuide.md
@@ -8,20 +8,20 @@ OMA Lightweight M2M IoT Agent: User and Development Guide
 * [Development](#development)
 
 
-# <a name="overview"> Overview </a>
+#  Overview
 The Lightweight M2M IoT Agent is a standard Fiware IoT Agent that implements the bridge of the OMA Lightweight M2M protocol
-with the internal protocol for the FIWARE components (OMA NGSI). This IoT Agent is based in the public 
-Node.js IoT Agent Library, where more information can be found about what the IoT Agents are and their different APIs. 
+with the internal protocol for the FIWARE components (OMA NGSI). This IoT Agent is based in the public
+Node.js IoT Agent Library, where more information can be found about what the IoT Agents are and their different APIs.
 
 This project has, then, two APIs:
-* The South Bound (LWM2M): information about it can be found in the [OMA Lightweight M2M](http://openmobilealliance.org/iot/lightweight-m2m-lwm2m) official page. Information about the subset of Lightweight M2M already supported can be found in the [LWM2M Library for Node.js](https://github.com/telefonicaid/lwm2m-node-lib) we are using.
-* The North Bound Administration API: all the IoT Agents share a single Administration API, and it can be found in the [Node.JS IoT Agent Library Documentation](https://github.com/telefonicaid/iotagent-node-lib).
-* The North Bound NGSI API: information about the northbound NGSI mapping can be obtained in the same Node.JS IOTA Library documentation.
- 
+* The API for traffic south of the IoT Agent (LWM2M): information about it can be found in the [OMA Lightweight M2M](http://openmobilealliance.org/iot/lightweight-m2m-lwm2m) official page. Information about the subset of Lightweight M2M already supported can be found in the [LWM2M Library for Node.js](https://github.com/telefonicaid/lwm2m-node-lib) we are using.
+* The North Port Administration API: all the IoT Agents share a single Administration API, and it can be found in the [Node.JS IoT Agent Library Documentation](https://github.com/telefonicaid/iotagent-node-lib).
+* The API for traffic north of the IoT Agent (NGSI): information about the North Port NGSI mapping can be obtained in the same Node.JS IOTA Library documentation.
+
 You will find examples and more detailed information in the Getting Started howtos below.
- 
-# <a name="gettingstarted"> Getting started </a>
-This document links a set of howtos oriented to give a quick step-by-step example on how to use the agent with 
+
+# Getting started
+This document links a set of howtos oriented to give a quick step-by-step example on how to use the agent with
 different types of configurations. It's important to remark that those configuration options are not mutually exclusive:
 an IoT Agent can have some device preprovisioned, some configuration groups defined and some static configurations also,
 each for different types of devices.
@@ -32,7 +32,7 @@ Some of the guides will share the use of a faked device type called `Robot` with
 * have a passive attribute called `Message` with type `string`, mapped to the LWM2M resource ID /7392/0/2.
 * have a command attribute called `Position` with type `location`, mapped to the LWM2M resource ID /7392/0/3.
 
-Some guides will show the use of the automatic OMA Registry mapping, using a faked device of type 'WeatherBaloon', 
+Some guides will show the use of the automatic OMA Registry mapping, using a faked device of type 'WeatherBaloon',
 with the following characteristics:
 * be part of the service `weather` and subservice `/baloons`.
 * a passive attribute with resource ID /6/0/0 (Position: Longitude).
@@ -48,25 +48,29 @@ provisioning each device before sending its measures.
 for being autoprovisioned when they register in the agent.
 * [Static Configuration Guide](staticConfiguration.md): this guide shows how to configure static routes that map incoming
 devices to different statically configured types.
- 
-# <a name="testing"> Testing </a>
+
+# Testing
 The IoT Agent comes with a test suite to check the main functionalities. In order to execute the test suite you must have the Grunt client installed. You can install it using the following command (you will need root permissions):
-```
+
+```bash
 npm install -g grunt-cli
 ```
 Once the client is installed and the dependencies are downloaded, you can execute the tests using:
-```
+
+```bash
 grunt
 ```
 This will execute the functional tests and the syntax checking as well.
 
 NOTE: This are end to end tests, so they execute against real instances of the components (so make sure you have a real Context Broker configured in the config.js). Be aware that the tests clean the databases before and after they have been executed so DO NOT EXECUTE THIS TESTS ON PRODUCTION MACHINES.
 
-# <a name="development"> Development </a>
+# Development
+
 ## Project build
 The project is managed using Grunt Task Runner.
 
 For a list of available task, type
+
 ```bash
 grunt --help
 ```
@@ -77,7 +81,7 @@ The following sections show the available options in detail.
 
 ### Overview
 Being an Open Source project, everyone can contribute, provided that it respect the following points:
-* Before contributing any code, the author must make sure all the tests work (see below how to launch the tests). 
+* Before contributing any code, the author must make sure all the tests work (see below how to launch the tests).
 * Developed code must adhere to the syntax guidelines enforced by the linters.
 * Code must be developed following the branching model and changelog policies defined below.
 * For any new feature added, unit tests must be provided, following the example of the ones already created.
@@ -85,32 +89,40 @@ Being an Open Source project, everyone can contribute, provided that it respect 
 In order to start contributing:
 1. Fork this repository clicking on the "Fork" button on the upper-right area of the page.
 2. Clone your just forked repository:
-```
+
+```bash
 git clone https://github.com/your-github-username/lightweightm2m-iotagent.git
 ```
-3. Add the main lightweightm2m-iotagent repository as a remote to your forked repository (use any name for your remote 
+
+3. Add the main lightweightm2m-iotagent repository as a remote to your forked repository (use any name for your remote
 repository, it does not have to be lightweightm2m-iotagent, although we will use it in the next steps):
-```
+
+```bash
 git remote add lightweightm2m-iotagent https://github.com/telefonicaid/lightweightm2m-iotagent.git
 ```
 
-Before starting contributing, remember to synchronize the `develop` branch in your forked repository with the `develop` 
+Before starting contributing, remember to synchronize the `develop` branch in your forked repository with the `develop`
 branch in the main lightweightm2m-iotagent repository, by following this steps
 
 1. Change to your local `develop` branch (in case you are not in it already):
-```
+
+```bash
   git checkout develop
 ```
+
 2. Fetch the remote changes:
-```
+
+```bash
   git fetch lightweightm2m-iotagent
 ```
+
 3. Merge them:
-```
+
+```bash
   git rebase lightweightm2m-iotagent/develop
 ```
 
-Contributions following this guidelines will be added to the `develop` branch, and released in the next version. The 
+Contributions following this guidelines will be added to the `develop` branch, and released in the next version. The
 release process is explaind in the *Releasing* section below.
 
 
@@ -128,7 +140,7 @@ and the tests before creating the Pull Request.
 
 Bug fixes work the same way as other tasks, with the exception of the branch name, that should be called `bug/<bugName>`.
 
-In order to contribute to the repository, these same scheme should be replicated in the forked repositories, so the 
+In order to contribute to the repository, these same scheme should be replicated in the forked repositories, so the
 new features or fixes should all come from the current version of `develop` and end up in `develop` again.
 
 All the `task/*` and `bug/*` branches are temporary, and should be removed once they have been merged.
@@ -139,7 +151,7 @@ point to each of the released versions of the project, they are permanent and th
 ### Changelog
 The project contains a version changelog, called CHANGES_NEXT_RELEASE, that can be found in the root of the project.
 Whenever a new feature or bug fix is going to be merged with `develop`, a new entry should be added to this changelog.
-The new entry should contain the reference number of the issue it is solving (if any). 
+The new entry should contain the reference number of the issue it is solving (if any).
 
 When a new version is released, the changelog is cleared, and remains fixed in the last commit of that version. The
 content of the changelog is also moved to the release description in the Github release.
@@ -160,7 +172,7 @@ this as the development version).
 Its important to remark that this component's tests are End To End tests, that have some software requirements to be run.
 This requirements are the following:
 * An instance of MongoDB running in `localhost`.
-* An instance of Orion Context Broker running in the location configured in `testConfig.js` (defaults to the alias `oriondb`). 
+* An instance of Orion Context Broker running in the location configured in `testConfig.js` (defaults to the alias `oriondb`).
 This instance has to have the 1026 and 27017 open for connections coming from the Grunt tester.
 
 ### Libraries

--- a/docs/userGuide.md
+++ b/docs/userGuide.md
@@ -3,7 +3,7 @@ OMA Lightweight M2M IoT Agent: User and Development Guide
 # Index
 
 * [Overview](#overview)
-* [Getting Started](#gettingstarted)
+* [Getting started](#getting-started)
 * [Testing](#testing)
 * [Development](#development)
 
@@ -16,11 +16,12 @@ Node.js IoT Agent Library, where more information can be found about what the Io
 This project has, then, two APIs:
 * The API for traffic south of the IoT Agent (LWM2M): information about it can be found in the [OMA Lightweight M2M](http://openmobilealliance.org/iot/lightweight-m2m-lwm2m) official page. Information about the subset of Lightweight M2M already supported can be found in the [LWM2M Library for Node.js](https://github.com/telefonicaid/lwm2m-node-lib) we are using.
 * The North Port Administration API: all the IoT Agents share a single Administration API, and it can be found in the [Node.JS IoT Agent Library Documentation](https://github.com/telefonicaid/iotagent-node-lib).
-* The API for traffic north of the IoT Agent (NGSI): information about the North Port NGSI mapping can be obtained in the same Node.JS IOTA Library documentation.
+* The API for traffic north of the IoT Agent (NGSI): information about the North Port NGSI mapping can be obtained in the same Node.JS IoT Agent Library documentation.
 
 You will find examples and more detailed information in the Getting Started howtos below.
 
 # Getting started
+
 This document links a set of howtos oriented to give a quick step-by-step example on how to use the agent with
 different types of configurations. It's important to remark that those configuration options are not mutually exclusive:
 an IoT Agent can have some device preprovisioned, some configuration groups defined and some static configurations also,

--- a/lib/ngsiHandlers.js
+++ b/lib/ngsiHandlers.js
@@ -148,7 +148,7 @@ function ngsiUpdateHandler(id, type, service, subservice, attributes, callback) 
 
     var name = id.substring(0, id.indexOf(':'));
 
-    logger.debug(context, 'Handling device data update from the northbound for device [%s] of type [%s]', id, type);
+    logger.debug(context, 'Handling device data update from the north port for device [%s] of type [%s]', id, type);
     logger.debug(context, 'New attributes;\n%s', attributes);
 
     function updateDevice(ngsiDevice, lwm2mDevice, innerCallback) {
@@ -180,7 +180,7 @@ function ngsiUpdateHandler(id, type, service, subservice, attributes, callback) 
 function ngsiExecuteHandler(id, type, service, subservice, attributes, callback) {
     var name = id.substring(0, id.indexOf(':'));
 
-    logger.debug(context, 'Handling device command execution from the northbound for device [%s] of type [%s]',
+    logger.debug(context, 'Handling device command execution from the north port for device [%s] of type [%s]',
         id, type);
     logger.debug(context, 'Arguments: \n%s', attributes);
 
@@ -241,7 +241,7 @@ function ngsiExecuteHandler(id, type, service, subservice, attributes, callback)
 function ngsiQueryHandler(id, type, service, subservice, attributes, callback) {
     var name = id.substring(0, id.indexOf(':'));
 
-    logger.debug(context, 'Handling device data query from the northbound for device [%s] of type [%s]', id, type);
+    logger.debug(context, 'Handling device data query from the north port for device [%s] of type [%s]', id, type);
     logger.debug(context, 'New attributes;\n%s', attributes);
 
     function createContextElement(device, attributeValues, callback) {


### PR DESCRIPTION
After discussion with @dcalvoalonso 

With standard English usage, the “bound”  suffix in implies a direction e.g “Homeward bound" means "going **towards** my home”, therefore “Southbound” means "going **towards** the South”
In contrast, the phrase "to the North of” does not imply direction, it implies relative location — you can be to the North of a town, but travelling Southbound - i.e. towards the city.
The main common usage of Northbound/Southbound is found with motorway traffic reports e.g. “the Northbound carriageway is blocked"

Therefore the following usage is correct common English, and the existing documents should be corrected to use it: 

* Traffic **to the South of** the IoT Agent refers to the exchange of information and commands between a device and an IoT Agent (Native protocols)
Traffic **to the North of** the IoT Agent traffic considers the link between the IoT Agent  and the CB.  (NGSI)
* **Southbound** traffic refers to the commands sent from the CB down to the device
* **Northbound** traffic refers to the measurements sent up from the IoT device to the CB
* **Northbound** traffic also refers to the results of commands  sent up from the IoT device to the CB

I have updated the documents  and removed `<a>`  tags and added code highlights for ReadTheDocs whilst updating.