### PR TITLE
Remove `##Index` from ToC since it is not required

### DIFF
--- a/docs/administrationGuide.md
+++ b/docs/administrationGuide.md
@@ -1,6 +1,5 @@
 OMA Lightweight M2M IoT Agent: Administration Guide
 ==================
-# Index
 
 * [Prerequisites](#prerequisites)
 * [Installation](#installation)

--- a/docs/configurationProvisioning.md
+++ b/docs/configurationProvisioning.md
@@ -1,6 +1,5 @@
 Configuration Provisioning guide
 ==================
-# Index
 
 * [Overview](#overview)
 * [Installation](#installation)

--- a/docs/deviceProvisioning.md
+++ b/docs/deviceProvisioning.md
@@ -1,6 +1,6 @@
 Device Provisioning Guide
 ==================
-# Index
+
 * [Overview](#overview)
 * [Installation](#overview)
 * [Configuration](#overview)

--- a/docs/staticConfiguration.md
+++ b/docs/staticConfiguration.md
@@ -1,6 +1,6 @@
 Static Configuration Guide
 ==================
-# Index
+
 * [Overview](#overview)
 * [Installation](#installation)
 * [Configuration](#configuration)

--- a/docs/userGuide.md
+++ b/docs/userGuide.md
@@ -1,6 +1,5 @@
 OMA Lightweight M2M IoT Agent: User and Development Guide
 ==================
-# Index
 
 * [Overview](#overview)
 * [Getting started](#getting-started)


### PR DESCRIPTION
* The ToC is suppressed with the ReadtheDocs CSS
* The ToC Header cannot be suppressed without CSS3

Therefore the title of the ToC should be removed to avoid confusion

Related to telefonicaid/iotagent-node-lib/issues/648