### PR TITLE
Expose Code Coverage results to Coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,7 @@ before_install:
 
 before_script:
   - npm run lint
+
+after_script: 
+  - npm run test:coveralls
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <br>
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-iotagent-lwm2m.svg)](http://fiware-iotagent-lwm2m.readthedocs.org/en/latest/?badge=latest)
 [![Build badge](https://img.shields.io/travis/telefonicaid/lightweightm2m-iotagent.svg)](https://travis-ci.org/telefonicaid/lightweightm2m-iotagent/)
+[![Coverage Status](https://coveralls.io/repos/github/telefonicaid/lightweightm2m-iotagent/badge.svg?branch=master)](https://coveralls.io/github/telefonicaid/lightweightm2m-iotagent?branch=master)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/iot-lightweightm2m.svg)
 
 This Internet of Things Agent is designed to be a bridge between the

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
+    "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {
+    "coveralls": "^3.0.2",
     "istanbul": "~0.4.5",
     "jshint": "~2.9.6",
     "mocha": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {
-    "coveralls": "^3.0.2",
+    "coveralls": "~3.0.2",
     "istanbul": "~0.4.5",
     "jshint": "~2.9.6",
     "mocha": "5.2.0",


### PR DESCRIPTION
Expose Code Coverage results to Coveralls. Runs `npm test:coverage` after the unit tests and then sends the results to [coveralls](https://coveralls.io)

the repo needs to be exposed on coveralls as well (obviously) - see https://coveralls.io/repos/new

- SHOULD requirement from TSC