### PR TITLE
Adds roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,36 +156,7 @@ The latest OMA Lightweight M2M IoT Agent documentation is also available on [Rea
 
 ## Roadmap
 
-This product is a FIWARE Generic Enabler. If you would like to learn about the overall Roadmap of FIWARE, please check "Roadmap" on the [FIWARE Catalogue](https://www.fiware.org/developers/catalogue/).
-
-### Introduction
-
-This section elaborates on proposed new features or tasks which are expected to be added to the product in the foreseeable future.  There should be no assumption of a commitment to deliver these features on specific dates or in the order given. The development team will be doing their best to follow the proposed dates and priorities, but please bear in mind that plans to work on a given feature or task may be revised.  All information is provided as general guidelines only,  and this section may be revised to provide newer information at any time.
-
-This section has been last updated in January 2019. Please take into account is content could be obsolete.
-
-### Short term
-
-The following list of features are planned to be addressed in the short term, and incorporated in the next release of the product:
-- Docker image protects username and password using environment variables (#159).
-- Removal of warnings and deprecation warnings.
-- Usage example using [Eclipse Wakaama](https://github.com/eclipse/wakaama)
-- Creation of tutorial (#162)
-
-
-### Medium term
-
-The following list of features are planned to be addressed in the medium term, typically within the subsequent release(s) generated in the next 9 months after the next planned release:
-- Support to FIWARE complex data models.
-- Deployment instructions for high availability scenarios.
-- Migration to ECMAScript6 syntax.
-
-
-### Long term
-
-The following list of features are proposals regarding the longer-term evolution of the product even though the development of these features has not yet been scheduled for a release in the near future.  Please feel free to contact us if you wish to get involved in the implementation or influence the roadmap:
-- Integration of security features in LWM2M server: DTLS.
-- Implementation of authentication and authorization.
+The roadmap of this FIWARE GE is described [here](docs/roadmap.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,37 @@ The latest OMA Lightweight M2M IoT Agent documentation is also available on [Rea
 
 ---
 
+## Roadmap
+
+This product is a FIWARE Generic Enabler. If you would like to learn about the overall Roadmap of FIWARE, please check "Roadmap" on the [FIWARE Catalogue](https://www.fiware.org/developers/catalogue/).
+
+### Introduction
+
+This section elaborates on proposed new features or tasks which are expected to be added to the product in the foreseeable future.  There should be no assumption of a commitment to deliver these features on specific dates or in the order given. The development team will be doing their best to follow the proposed dates and priorities, but please bear in mind that plans to work on a given feature or task may be revised.  All information is provided as general guidelines only,  and this section may be revised to provide newer information at any time.
+
+### Short tem
+
+The following list of features are planned to be addressed in the short term, and incorporated in the next release of the product:
+- Docker image protects username and password using environment variables (#159).
+- Removal of warnings and deprecation warnings.
+- Usage example using [Eclipse Wakaama](https://github.com/eclipse/wakaama)
+- Creation of tutorial (#162)
+
+
+### Medium term
+
+The following list of features are planned to be addressed in the medium term, typically within the subsequent release(s) generated in the next 9 months after the next planned release:
+- Support to FIWARE complex data models.
+- Deployment instructions for high availability scenarios.
+- Migration to ECMAScript6 syntax.
+
+
+### Long term
+
+The following list of features are proposals regarding the longer-term evolution of the product even though the development of these features has not yet been scheduled for a release in the near future.  Please feel free to contact us if you wish to get involved in the implementation or influence the roadmap:
+- Integration of security features in LWM2M server: DTLS.
+- Implementation of authentication and authorization.
+
 ## License
 
 The IoT Agent for Lightweight Machine 2 Machine is licensed under Affero General

--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ Library [documentation](https://iotagent-node-lib.rtfd.io/).
 
 The latest OMA Lightweight M2M IoT Agent documentation is also available on [ReadtheDocs](https://fiware-iotagent-lwm2m.readthedocs.io/en/latest)
 
----
-
 ## Roadmap
 
 The roadmap of this FIWARE GE is described [here](docs/roadmap.md)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ check the FIWARE Catalogue entry for the
 -   [Install](#install)
 -   [Usage](#usage)
 -   [API](#api)
+-   [Roadmap](#roadmap)
 -   [License](#license)
 
 ## Background
@@ -161,7 +162,9 @@ This product is a FIWARE Generic Enabler. If you would like to learn about the o
 
 This section elaborates on proposed new features or tasks which are expected to be added to the product in the foreseeable future.  There should be no assumption of a commitment to deliver these features on specific dates or in the order given. The development team will be doing their best to follow the proposed dates and priorities, but please bear in mind that plans to work on a given feature or task may be revised.  All information is provided as general guidelines only,  and this section may be revised to provide newer information at any time.
 
-### Short tem
+This section has been last updated in January 2019. Please take into account is content could be obsolete.
+
+### Short term
 
 The following list of features are planned to be addressed in the short term, and incorporated in the next release of the product:
 - Docker image protects username and password using environment variables (#159).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,32 @@
+# IoT Agent for OMA LightWeight Machine2Machine Roadmap
+
+This product is a FIWARE Generic Enabler. If you would like to learn about the overall Roadmap of FIWARE, please check "Roadmap" on the [FIWARE Catalogue](https://www.fiware.org/developers/catalogue/).
+
+### Introduction
+
+This section elaborates on proposed new features or tasks which are expected to be added to the product in the foreseeable future.  There should be no assumption of a commitment to deliver these features on specific dates or in the order given. The development team will be doing their best to follow the proposed dates and priorities, but please bear in mind that plans to work on a given feature or task may be revised.  All information is provided as general guidelines only,  and this section may be revised to provide newer information at any time.
+
+This section has been last updated in January 2019. Please take into account is content could be obsolete.
+
+### Short term
+
+The following list of features are planned to be addressed in the short term, and incorporated in the next release of the product:
+- Docker image protects username and password using environment variables (#159).
+- Removal of warnings and deprecation warnings.
+- Usage example using [Eclipse Wakaama](https://github.com/eclipse/wakaama)
+- Creation of tutorial (#162)
+
+
+### Medium term
+
+The following list of features are planned to be addressed in the medium term, typically within the subsequent release(s) generated in the next 9 months after the next planned release:
+- Support to FIWARE complex data models.
+- Deployment instructions for high availability scenarios.
+- Migration to ECMAScript6 syntax.
+
+
+### Long term
+
+The following list of features are proposals regarding the longer-term evolution of the product even though the development of these features has not yet been scheduled for a release in the near future.  Please feel free to contact us if you wish to get involved in the implementation or influence the roadmap:
+- Integration of security features in LWM2M server: DTLS.
+- Implementation of authentication and authorization.


### PR DESCRIPTION
This PR aims to fulfil one of the *MUST* requirements of FIWARE for GEs.

It just adds a *Roadmap* section in the README.md file, following the template under https://github.com/Fiware/contribution-requirements/blob/63c82b432c4d4141166ba57c403842e08eafea90/docs/GE_roadmap_template.md