### PR TITLE
bugfix for entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,4 +65,4 @@ else
     fi
 fi
 
-pm2-runtime /opt/iota-lwm2m/bin/lwm2mAgent
+pm2-runtime /opt/iota-lwm2m/bin/lwm2mAgent.js


### PR DESCRIPTION
Broken since previous PR https://github.com/telefonicaid/lightweightm2m-iotagent/pull/185
No CNR update is needed.

```
iot-iota-lwm2m              | ***********************************************
iot-iota-lwm2m              | WARNING: It is recommended to enable authentication for secure connection
iot-iota-lwm2m              | ***********************************************
iot-iota-lwm2m              | 2019-04-16T12:19:08: PM2 log: Launching in no daemon mode
iot-iota-lwm2m              | 2019-04-16T12:19:08: PM2 error: script not found : /opt/iota-lwm2m/bin/lwm2mAgent
iot-iota-lwm2m              | 2019-04-16T12:19:09: PM2 log: PM2 successfully stopped
```