### PR TITLE
Add PM2_ENABLED flag to Docker

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Set Nodejs 8 as minimum version in packages.json (effectively removing Nodev6 from supported versions)
+- ADD PM2_ENABLED flag to Docker

--- a/docker/README.md
+++ b/docker/README.md
@@ -160,7 +160,7 @@ docker run --name iotagent -e PM2_ENABLED=true -d fiware/lightweightm2m-iotagent
 
 Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
 your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
-Kubenetes)
+[Kubernetes](https://kubernetes.io/))
 
 ### Docker Secrets
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -149,6 +149,19 @@ COPY . /opt/iota-lwm2m/
 
 Full instructions can be found within the `Dockerfile` itself.
 
+### Using PM2
+
+The IoT Agent within the Docker image can be run encapsulated within the [pm2](http://pm2.keymetrics.io/) Process
+Manager by adding the `PM2_ENABLED` environment variable.
+
+```console
+docker run --name iotagent -e PM2_ENABLED=true -d fiware/lightweightm2m-iotagent
+```
+
+Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
+your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
+Kubenetes)
+
 ### Docker Secrets
 
 As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to some sensitive

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,4 +65,12 @@ else
     fi
 fi
 
-pm2-runtime /opt/iota-lwm2m/bin/lwm2mAgent.js
+if [[  -z "$PM2_ENABLED" ]]; then
+    echo "INFO: IoT Agent running standalone"
+    node /opt/iota-lwm2m/bin/lwm2mAgent.js
+else
+    echo "***********************************************"
+    echo "INFO: IoT Agent encapsulated by pm2-runtime see https://pm2.io/doc/en/runtime/integration/docker/"
+    echo "***********************************************"
+    pm2-runtime /opt/iota-lwm2m/bin/lwm2mAgent.js
+fi


### PR DESCRIPTION
This PR is a potential fix for https://github.com/telefonicaid/iotagent-node-lib/issues/790

* Update entrypoint to use/not use pm2
* Add `PM2_ENABLED` to Docker README
* Update CNR.