### PR TITLE
Implements NGSIv2 context forwarding (from PR #186 with additions)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: support to lazy attributes and commands based in NGSIv2 (#104)

--- a/lib/ngsiHandlers.js
+++ b/lib/ngsiHandlers.js
@@ -247,7 +247,7 @@ function ngsiQueryHandler(id, type, service, subservice, attributes, callback) {
     logger.debug(context, 'Handling device data query from the north port for device [%s] of type [%s]', id, type);
     logger.debug(context, 'New attributes;\n%s', attributes);
 
-    function createContextElement(device, attributeValues, callback) {
+    function createContextElementNgsi1(device, attributeValues, callback) {
         var contextElement = {
             type: type,
             isPattern: false,
@@ -279,6 +279,45 @@ function ngsiQueryHandler(id, type, service, subservice, attributes, callback) {
         }
 
         callback(null, contextElement);
+    }
+
+    function createContextElementNgsi2(device, attributeValues, callback) {
+        var contextElement = {
+            type: type,
+            id: id
+        };
+
+        for (var i = 0; i < attributes.length; i++) {
+            var attributeType = 'string',
+                lazySet = [];
+
+            if (device.lazy) {
+                lazySet = device.lazy;
+            } else if (config.ngsi.types[type] && config.ngsi.types[type].lazy) {
+                lazySet = config.ngsi.types[type].lazy;
+            }
+
+            for (var j = 0; j < lazySet.length; j++) {
+                if (lazySet[j].name === encodeURI(attributes[i])) {
+                    attributeType = lazySet[j].type;
+                }
+            }
+
+            contextElement[encodeURI(attributes[i])] = {
+                type: attributeType,
+                value: attributeValues[i]
+            };
+        }
+
+        callback(null, contextElement);
+    }
+
+    function createContextElement(device, attributeValues, callback) {
+        if (iotAgentLib.configModule.checkNgsi2()) {
+            createContextElementNgsi2(device, attributeValues, callback);
+        } else {
+            createContextElementNgsi1(device, attributeValues, callback);
+        }
     }
 
     function readAttributes(attributes, ngsiDevice, lwm2mDevice, innerCallback) {

--- a/lib/ngsiHandlers.js
+++ b/lib/ngsiHandlers.js
@@ -159,6 +159,12 @@ function ngsiUpdateHandler(id, type, service, subservice, attributes, callback) 
         async.map(attributes, async.apply(writeAttribute, ngsiDevice, lwm2mDevice), innerCallback);
     }
 
+    if (iotAgentLib.configModule.checkNgsi2()) {
+        for (var i = 0; i < attributes.length; i++) {
+            attributes[i].name = decodeURI(attributes[i].name);
+        }
+    }
+
     if (!name) {
         name = id;
     }
@@ -329,6 +335,12 @@ function ngsiQueryHandler(id, type, service, subservice, attributes, callback) {
 
     if (!name) {
         name = id;
+    }
+
+    if (iotAgentLib.configModule.checkNgsi2()) {
+        for (var i = 0; i < attributes.length; i++) {
+            attributes[i] = decodeURI(attributes[i]);
+        }
     }
 
     iotAgentLib.getDeviceByName(id, service, subservice, function(error, ngsiDevice) {

--- a/lib/ngsiUtils.js
+++ b/lib/ngsiUtils.js
@@ -75,21 +75,26 @@ function updateEntityNgsi1(host, port, service, subservice, name, type, attribut
  */
 function updateEntityNgsi2(host, port, service, subservice, name, type, attributes, callback) {
     var options = {
-        url: 'http://' + host + ':' + port + '/v2/entities/attrs',
+        url: 'http://' + host + ':' + port + '/v2/op/update',
         method: 'POST',
         headers: {
             'fiware-service': service,
             'fiware-servicepath': subservice
         },
         json: {
-            id: name,
-            attributes: {}
+            actionType: 'append',
+            entities: [
+                {
+                    id: name,
+                    type: type
+                }
+            ]
         }
     };
 
     for (var i = 0; i < attributes.length; i++) {
         if (attributes[i].name && attributes[i].type) {
-            options.json.attributes[attributes[i].name] = {
+            options.json.entities[0][attributes[i].name] = {
                 value: attributes[i].value,
                 type: attributes[i].type,
                 metadata: attributes[i].metadata
@@ -132,7 +137,7 @@ function updateEntity(host, port, service, subservice, name, type, attributes, c
  */
 function queryEntityNgsi2(host, port, service, subservice, id, type, attributes, callback) {
     var options = {
-        url: 'http://' + host + ':' + port + '/v2/entities/' + id + '/attrs',
+        url: 'http://' + host + ':' + port + '/v2/entities?id=' + id,
         method: 'GET',
         headers: {
             'fiware-service': service,
@@ -142,8 +147,12 @@ function queryEntityNgsi2(host, port, service, subservice, id, type, attributes,
         json: true
     };
 
+    if (type) {
+        options.url += '&type=' + type;
+    }
+
     if (attributes.length > 0) {
-        var attributesQueryParam = '?attrs=';
+        var attributesQueryParam = '&attrs=';
         for (var i = 0; i < attributes.length; i++) {
             attributesQueryParam += attributes[i];
             if (i < attributes.length - 1) {
@@ -154,6 +163,8 @@ function queryEntityNgsi2(host, port, service, subservice, id, type, attributes,
         options.url += attributesQueryParam;
     }
 
+    options.url = encodeURI(options.url);
+    options.url = options.url.replace(/%/g, '%25');
     request(options, callback);
 }
 

--- a/lib/ngsiUtils.js
+++ b/lib/ngsiUtils.js
@@ -82,7 +82,7 @@ function updateEntityNgsi2(host, port, service, subservice, name, type, attribut
             'fiware-servicepath': subservice
         },
         json: {
-            actionType: 'append',
+            actionType: 'update',
             entities: [
                 {
                     id: name,
@@ -94,7 +94,7 @@ function updateEntityNgsi2(host, port, service, subservice, name, type, attribut
 
     for (var i = 0; i < attributes.length; i++) {
         if (attributes[i].name && attributes[i].type) {
-            options.json.entities[0][attributes[i].name] = {
+            options.json.entities[0][encodeURI(attributes[i].name)] = {
                 value: attributes[i].value,
                 type: attributes[i].type,
                 metadata: attributes[i].metadata
@@ -137,34 +137,36 @@ function updateEntity(host, port, service, subservice, name, type, attributes, c
  */
 function queryEntityNgsi2(host, port, service, subservice, id, type, attributes, callback) {
     var options = {
-        url: 'http://' + host + ':' + port + '/v2/entities?id=' + id,
-        method: 'GET',
+        url: 'http://' + host + ':' + port + '/v2/op/query',
+        method: 'POST',
         headers: {
             'fiware-service': service,
-            'fiware-servicepath': subservice,
-            Accept: 'application/json'
+            'fiware-servicepath': subservice
         },
-        json: true
+        json: true,
+        body: {
+            entities: [
+                {
+                    id: id
+                }
+            ]
+        }
     };
 
     if (type) {
-        options.url += '&type=' + type;
+        options.body.entities[0].type = type;
     }
 
     if (attributes.length > 0) {
-        var attributesQueryParam = '&attrs=';
+        var attributesArray = [];
         for (var i = 0; i < attributes.length; i++) {
-            attributesQueryParam += attributes[i];
-            if (i < attributes.length - 1) {
-                attributesQueryParam += ',';
-            }
+            var att = encodeURI(attributes[i]);
+            attributesArray.push(att);
         }
 
-        options.url += attributesQueryParam;
+        options.body.attrs = attributesArray;
     }
 
-    options.url = encodeURI(options.url);
-    options.url = options.url.replace(/%/g, '%25');
     request(options, callback);
 }
 

--- a/lib/services/lwm2mHandlers/registration.js
+++ b/lib/services/lwm2mHandlers/registration.js
@@ -186,7 +186,11 @@ function addUnsupportedAttributes(payload, configuration, deviceInformation, cal
     function toNgsi(previous, value) {
         if (omaRegistry[value.objectType]) {
             if (omaRegistry[value.objectType].resources) {
-                return previous.concat(omaRegistry[value.objectType].resources);
+                // JSON.parse(JSON.stringify(...)) deep clones the array and avoids inter function calls modifications
+                // of omaRegistry() done later by encodeURI(deviceInformation.lazy[att].name). Useful refs:
+                // https://medium.com/@gamshan001/javascript-deep-copy-for-array-and-object-97e3d4bc401a
+                // https://www.samanthaming.com/tidbits/35-es6-way-to-clone-an-array
+                return previous.concat(JSON.parse(JSON.stringify(omaRegistry[value.objectType].resources)));
             } else {
                 // In NGSIv2, spaces cannot be used in attributes' names. Therefore, we use percent-enconding.
                 if (iotAgentLib.configModule.checkNgsi2()) {

--- a/lib/services/lwm2mHandlers/registration.js
+++ b/lib/services/lwm2mHandlers/registration.js
@@ -225,7 +225,11 @@ function addUnsupportedAttributes(payload, configuration, deviceInformation, cal
     }
 
     deviceInformation.lazy = deviceInformation.lazy.concat(newAttributes);
-
+    if (iotAgentLib.configModule.checkNgsi2()) {
+        for (var att in deviceInformation.lazy) {
+            deviceInformation.lazy[att].name = encodeURI(deviceInformation.lazy[att].name);
+        }
+    }
     callback(null, deviceInformation);
 }
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cheerio": "1.0.0-rc.2",
     "xmldom": "0.1.27",
     "logops": "2.1.0",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#task/lazyAttsNgsiv2-pr762",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage",
-    "test": "mocha --recursive 'test/**/*.js' --reporter spec --timeout 5000 --ui bdd --exit",
+    "test": "mocha 'test/unit/tests.js' 'test/unit/ngsiv2/tests.js' --reporter spec --timeout 5000 --ui bdd --exit",
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
     "lint:md": "remark -f 'README.md' docs",
@@ -50,7 +50,7 @@
     "cheerio": "1.0.0-rc.2",
     "xmldom": "0.1.27",
     "logops": "2.1.0",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "git://github.com/dcalvoalonso/iotagent-node-lib.git#task/lazyAttsNgsiv2",
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cheerio": "1.0.0-rc.2",
     "xmldom": "0.1.27",
     "logops": "2.1.0",
-    "iotagent-node-lib": "git://github.com/fgalan/iotagent-node-lib.git#task/lazyAttsNgsiv2",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#task/lazyAttsNgsiv2-pr762",
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cheerio": "1.0.0-rc.2",
     "xmldom": "0.1.27",
     "logops": "2.1.0",
-    "iotagent-node-lib": "git://github.com/dcalvoalonso/iotagent-node-lib.git#task/lazyAttsNgsiv2",
+    "iotagent-node-lib": "git://github.com/fgalan/iotagent-node-lib.git#task/lazyAttsNgsiv2",
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {

--- a/test/unit/ngsiv2/active-attributes-test.js
+++ b/test/unit/ngsiv2/active-attributes-test.js
@@ -95,9 +95,9 @@ describe('Active attributes test', function() {
                         body
                     ) {
                         should.not.exist(error);
-                        should.exist(body.pressure);
-                        should.exist(body.pressure.value);
-                        body.pressure.value.should.equal('89');
+                        should.exist(body[0].pressure);
+                        should.exist(body[0].pressure.value);
+                        body[0].pressure.value.should.equal('89');
                         done();
                     });
                 }, 1000);
@@ -129,8 +129,9 @@ describe('Active attributes test', function() {
                         ) {
                             should.not.exist(error);
                             should.exist(body);
-                            should.exist(body.pressure.value);
-                            body.pressure.value.should.equal('19');
+                            body.should.be.instanceof(Array).and.have.lengthOf(1);
+                            should.exist(body[0].pressure.value);
+                            body[0].pressure.value.should.equal('19');
                             done();
                         });
                     }, 1000);

--- a/test/unit/ngsiv2/commands-test.js
+++ b/test/unit/ngsiv2/commands-test.js
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-iotagent-lib
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+'use strict';
+
+var config = require('./testConfig'),
+    lwm2mClient = require('lwm2m-node-lib').client,
+    request = require('request'),
+    iotAgent = require('../../../lib/iotAgentLwm2m'),
+    ngsiTestUtils = require('./../../../lib/ngsiUtils'),
+    mongoUtils = require('../mongoDBUtils'),
+    async = require('async'),
+    apply = async.apply,
+    utils = require('../../utils'),
+    should = require('should'),
+    clientConfig = {
+        host: 'localhost',
+        port: '60001',
+        endpointName: 'TestClient',
+        url: '/robot',
+        ipProtocol: 'udp4'
+    },
+    ngsiClient = ngsiTestUtils.create(
+        config.ngsi.contextBroker.host,
+        config.ngsi.contextBroker.port,
+        'smartgondor',
+        '/gardens'
+    ),
+    deviceInformation;
+
+describe('Command attributes test', function() {
+    beforeEach(function(done) {
+        lwm2mClient.init(config);
+
+        async.series(
+            [
+                apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
+                apply(iotAgent.start, config),
+                apply(lwm2mClient.registry.create, '/5000/0')
+            ],
+            function(error) {
+                lwm2mClient.register(
+                    clientConfig.host,
+                    clientConfig.port,
+                    clientConfig.url,
+                    clientConfig.endpointName,
+                    function(error, result) {
+                        deviceInformation = result;
+                        setTimeout(done, 1000);
+                    }
+                );
+            }
+        );
+    });
+
+    afterEach(function(done) {
+        async.series(
+            [
+                apply(lwm2mClient.unregister, deviceInformation),
+                iotAgent.stop,
+                apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
+                lwm2mClient.registry.reset
+            ],
+            done
+        );
+    });
+
+    describe('When a command value is changed in Orion for a statically configured type', function() {
+        beforeEach(function(done) {
+            lwm2mClient.register(
+                clientConfig.host,
+                clientConfig.port,
+                clientConfig.url,
+                clientConfig.endpointName,
+                function(error, result) {
+                    deviceInformation = result;
+                    async.series(
+                        [
+                            async.apply(lwm2mClient.registry.create, '/9090/0'),
+                            async.apply(lwm2mClient.registry.setResource, '/9090/0', '0', '[]')
+                        ],
+                        done
+                    );
+                }
+            );
+        });
+
+        it('should send the execution command to the LWM2M client', function(done) {
+            var handleExecuted = false,
+                attributes = [
+                    {
+                        name: 'position',
+                        type: 'Array',
+                        value: '[15,6234,312]'
+                    }
+                ];
+
+            function handleExecute(objectType, objectId, resourceId, args, callback) {
+                objectType.should.equal('9090');
+                objectId.should.equal('0');
+                resourceId.should.equal('0');
+                handleExecuted = true;
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'execute', handleExecute);
+
+            ngsiClient.update('TestClient:Robot', 'Robot', attributes, function(error, response, body) {
+                should.not.exist(error);
+                handleExecuted.should.equal(true);
+                done();
+            });
+        });
+
+        it('should return a 200 OK statusCode', function(done) {
+            var attributes = [
+                {
+                    name: 'position',
+                    type: 'Array',
+                    value: '[15,6234,312]'
+                }
+            ];
+
+            function handleExecute(objectType, objectId, resourceId, args, callback) {
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'execute', handleExecute);
+
+            ngsiClient.update('TestClient:Robot', 'Robot', attributes, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+    });
+
+    describe('When a command value is changed in Orion for a preprovisioned device', function() {
+        var options = {
+            url: 'http://localhost:' + config.ngsi.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/provisionExamples/provisionDeviceWithCommands.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function(done) {
+            request(options, function(error, response, body) {
+                lwm2mClient.register(clientConfig.host, clientConfig.port, clientConfig.url, 'TestRobotPre', function(
+                    error,
+                    result
+                ) {
+                    deviceInformation = result;
+                    async.series(
+                        [
+                            async.apply(lwm2mClient.registry.create, '/6789/0'),
+                            async.apply(lwm2mClient.registry.setResource, '/6789/0', '17', '[]')
+                        ],
+                        done
+                    );
+                });
+            });
+        });
+
+        it('should send the execution command to the LWM2M client', function(done) {
+            var handleExecuted = false,
+                attributes = [
+                    {
+                        name: 'position',
+                        type: 'Array',
+                        value: '[15,6234,312]'
+                    }
+                ];
+
+            function handleExecute(objectType, objectId, resourceId, args, callback) {
+                objectType.should.equal('6789');
+                objectId.should.equal('0');
+                resourceId.should.equal('17');
+                handleExecuted = true;
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'execute', handleExecute);
+
+            ngsiClient.update('RobotPre:TestRobotPre', 'RobotPre', attributes, function(error, response, body) {
+                should.not.exist(error);
+                handleExecuted.should.equal(true);
+
+                done();
+            });
+        });
+        it('should return a 200 OK statusCode');
+    });
+
+    describe('When a command value is changed in Orion for a device registering in a configuration', function() {
+        it('should send the execution command to the LWM2M client');
+        it('should return a 200 OK statusCode');
+    });
+});

--- a/test/unit/ngsiv2/commands-test.js
+++ b/test/unit/ngsiv2/commands-test.js
@@ -41,7 +41,7 @@ var config = require('./testConfig'),
         url: '/robot',
         ipProtocol: 'udp4'
     },
-    ngsiClient = ngsiTestUtils.create(
+    ngsiClient = ngsiTestUtils.createNgsi2(
         config.ngsi.contextBroker.host,
         config.ngsi.contextBroker.port,
         'smartgondor',
@@ -58,29 +58,6 @@ describe('Command attributes test', function() {
                 apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
                 apply(iotAgent.start, config),
                 apply(lwm2mClient.registry.create, '/5000/0')
-            ],
-            function(error) {
-                lwm2mClient.register(
-                    clientConfig.host,
-                    clientConfig.port,
-                    clientConfig.url,
-                    clientConfig.endpointName,
-                    function(error, result) {
-                        deviceInformation = result;
-                        setTimeout(done, 1000);
-                    }
-                );
-            }
-        );
-    });
-
-    afterEach(function(done) {
-        async.series(
-            [
-                apply(lwm2mClient.unregister, deviceInformation),
-                iotAgent.stop,
-                apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
-                lwm2mClient.registry.reset
             ],
             done
         );
@@ -103,6 +80,18 @@ describe('Command attributes test', function() {
                         done
                     );
                 }
+            );
+        });
+
+        afterEach(function(done) {
+            async.series(
+                [
+                    apply(lwm2mClient.unregister, deviceInformation),
+                    iotAgent.stop,
+                    apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
+                    lwm2mClient.registry.reset
+                ],
+                done
             );
         });
 
@@ -183,6 +172,18 @@ describe('Command attributes test', function() {
                     );
                 });
             });
+        });
+
+        afterEach(function(done) {
+            async.series(
+                [
+                    apply(lwm2mClient.unregister, deviceInformation),
+                    iotAgent.stop,
+                    apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
+                    lwm2mClient.registry.reset
+                ],
+                done
+            );
         });
 
         it('should send the execution command to the LWM2M client', function(done) {

--- a/test/unit/ngsiv2/passive-attributes-test.js
+++ b/test/unit/ngsiv2/passive-attributes-test.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-iotagent-lib
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+'use strict';
+
+var config = require('./testConfig'),
+    lwm2mClient = require('lwm2m-node-lib').client,
+    iotAgent = require('../../../lib/iotAgentLwm2m'),
+    ngsiTestUtils = require('./../../../lib/ngsiUtils'),
+    mongoUtils = require('../mongoDBUtils'),
+    async = require('async'),
+    apply = async.apply,
+    should = require('should'),
+    clientConfig = {
+        host: 'localhost',
+        port: '60001',
+        endpointName: 'TestClient',
+        url: '/light',
+        ipProtocol: 'udp4'
+    },
+    ngsiClient = ngsiTestUtils.create(
+        config.ngsi.contextBroker.host,
+        config.ngsi.contextBroker.port,
+        'smartgondor',
+        '/gardens'
+    ),
+    deviceInformation;
+
+describe('Passive attributes test', function() {
+    beforeEach(function(done) {
+        lwm2mClient.init(config);
+        async.series(
+            [
+                async.apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
+                async.apply(iotAgent.start, config),
+                lwm2mClient.registry.reset
+            ],
+            done
+        );
+    });
+
+    afterEach(function(done) {
+        async.series(
+            [
+                apply(lwm2mClient.unregister, deviceInformation),
+                iotAgent.stop,
+                apply(mongoUtils.cleanDbs, config.ngsi.contextBroker.host),
+                lwm2mClient.registry.reset
+            ],
+            done
+        );
+    });
+
+    describe('When a passive attribute of the entity corresponding to a device is queried in Orion', function() {
+        beforeEach(function(done) {
+            lwm2mClient.register(
+                clientConfig.host,
+                clientConfig.port,
+                clientConfig.url,
+                clientConfig.endpointName,
+                function(error, result) {
+                    deviceInformation = result;
+                    async.series(
+                        [
+                            async.apply(lwm2mClient.registry.create, '/6000/0'),
+                            async.apply(lwm2mClient.registry.setResource, '/6000/0', '3', '12')
+                        ],
+                        done
+                    );
+                }
+            );
+        });
+
+        it('should query the value in the LWM2M device via the IoT Agent', function(done) {
+            var handleExecuted = false;
+
+            function handleRead(objectType, objectId, resourceId, value, callback) {
+                objectType.should.equal('6000');
+                objectId.should.equal('0');
+                resourceId.should.equal('3');
+                handleExecuted = true;
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'read', handleRead);
+
+            ngsiClient.query('TestClient:Light', 'Light', ['luminescence'], function(error, response, body) {
+                should.not.exist(error);
+                handleExecuted.should.equal(true);
+                should.exist(body);
+                body.should.be.instanceof(Array).and.have.lengthOf(1);
+                body[0].id.should.equal('TestClient:Light');
+                body[0].type.should.equal('Light');
+                should.exist(body[0].luminescence);
+                body[0].luminescence.type.should.equal('Lumens');
+                body[0].luminescence.value.should.equal('12');
+                done();
+            });
+        });
+    });
+
+    describe('When a passive attribute of the entity corresponding to a device is modified in Orion', function() {
+        var attributes = [
+            {
+                name: 'luminescence',
+                type: 'Lumens',
+                value: '8375'
+            }
+        ];
+
+        beforeEach(function(done) {
+            lwm2mClient.register(
+                clientConfig.host,
+                clientConfig.port,
+                clientConfig.url,
+                clientConfig.endpointName,
+                function(error, result) {
+                    deviceInformation = result;
+                    async.series(
+                        [
+                            async.apply(lwm2mClient.registry.create, '/6000/0'),
+                            async.apply(lwm2mClient.registry.setResource, '/6000/0', '3', '12')
+                        ],
+                        done
+                    );
+                }
+            );
+        });
+
+        it('should write the value in the LWM2M device via the IoT Agent', function(done) {
+            var handleExecuted = false;
+
+            function handleWrite(objectType, objectId, resourceId, value, callback) {
+                objectType.should.equal('6000');
+                objectId.should.equal('0');
+                resourceId.should.equal('3');
+                handleExecuted = true;
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'write', handleWrite);
+
+            ngsiClient.update('TestClient:Light', 'Light', attributes, function(error, response, body) {
+                should.not.exist(error);
+                handleExecuted.should.equal(true);
+
+                done();
+            });
+        });
+    });
+
+    describe('When a passive OMA attribute request is queried in orion', function() {
+        beforeEach(function(done) {
+            async.series(
+                [
+                    async.apply(lwm2mClient.registry.create, '/0/0'),
+                    async.apply(lwm2mClient.registry.setResource, '/0/0', '0', 'coap://localhost')
+                ],
+                function(error) {
+                    lwm2mClient.register(
+                        clientConfig.host,
+                        clientConfig.port,
+                        clientConfig.url,
+                        clientConfig.endpointName,
+                        function(error, result) {
+                            deviceInformation = result;
+                            done();
+                        }
+                    );
+                }
+            );
+        });
+
+        it('should query the value in the LWM2M device via the IoT Agent using the OMA Mapping', function(done) {
+            var handleExecuted = false;
+
+            function handleRead(objectType, objectId, resourceId, value, callback) {
+                objectType.should.equal('0');
+                objectId.should.equal('0');
+                resourceId.should.equal('0');
+                handleExecuted = true;
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'read', handleRead);
+
+            ngsiClient.query('TestClient:Light', 'Light', ['LWM2M Server URI'], function(error, response, body) {
+                should.not.exist(error);
+                handleExecuted.should.equal(true);
+                should.exist(body);
+                body.should.be.instanceof(Array).and.have.lengthOf(1);
+                body[0].id.should.equal('TestClient:Light');
+                body[0].type.should.equal('Light');
+                should.exist(body[0]['LWM2M%20Server%20URI']);
+                body[0]['LWM2M%20Server%20URI'].type.should.equal('string');
+                body[0]['LWM2M%20Server%20URI'].value.should.equal('coap://localhost');
+                done();
+            });
+        });
+    });
+    describe('When a passive OMA attribute is modified in Orion', function() {
+        var attributes = [
+            {
+                name: 'LWM2M Server URI',
+                type: 'string',
+                value: 'coap://remotehost:9786'
+            }
+        ];
+
+        beforeEach(function(done) {
+            async.series(
+                [
+                    async.apply(lwm2mClient.registry.create, '/0/0'),
+                    async.apply(lwm2mClient.registry.setResource, '/0/0', '0', 'coap://localhost')
+                ],
+                function(error) {
+                    lwm2mClient.register(
+                        clientConfig.host,
+                        clientConfig.port,
+                        clientConfig.url,
+                        clientConfig.endpointName,
+                        function(error, result) {
+                            deviceInformation = result;
+                            done();
+                        }
+                    );
+                }
+            );
+        });
+
+        it('should write the value in the LWM2M device via the IoT Agent', function(done) {
+            var handleExecuted = false;
+
+            function handleWrite(objectType, objectId, resourceId, value, callback) {
+                objectType.should.equal('0');
+                objectId.should.equal('0');
+                resourceId.should.equal('0');
+                handleExecuted = true;
+                callback();
+            }
+
+            lwm2mClient.setHandler(deviceInformation.serverInfo, 'write', handleWrite);
+
+            ngsiClient.update('TestClient:Light', 'Light', attributes, function(error, response, body) {
+                should.not.exist(error);
+                handleExecuted.should.equal(true);
+
+                done();
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/passive-attributes-test.js
+++ b/test/unit/ngsiv2/passive-attributes-test.js
@@ -39,7 +39,7 @@ var config = require('./testConfig'),
         url: '/light',
         ipProtocol: 'udp4'
     },
-    ngsiClient = ngsiTestUtils.create(
+    ngsiClient = ngsiTestUtils.createNgsi2(
         config.ngsi.contextBroker.host,
         config.ngsi.contextBroker.port,
         'smartgondor',
@@ -213,12 +213,13 @@ describe('Passive attributes test', function() {
                 body[0].id.should.equal('TestClient:Light');
                 body[0].type.should.equal('Light');
                 should.exist(body[0]['LWM2M%20Server%20URI']);
-                body[0]['LWM2M%20Server%20URI'].type.should.equal('string');
+                body[0]['LWM2M%20Server%20URI'].type.should.equal('String');
                 body[0]['LWM2M%20Server%20URI'].value.should.equal('coap://localhost');
                 done();
             });
         });
     });
+
     describe('When a passive OMA attribute is modified in Orion', function() {
         var attributes = [
             {
@@ -265,7 +266,6 @@ describe('Passive attributes test', function() {
             ngsiClient.update('TestClient:Light', 'Light', attributes, function(error, response, body) {
                 should.not.exist(error);
                 handleExecuted.should.equal(true);
-
                 done();
             });
         });

--- a/test/unit/ngsiv2/registration-test.js
+++ b/test/unit/ngsiv2/registration-test.js
@@ -289,7 +289,8 @@ describe('Device auto-registration test', function() {
                         ) {
                             should.not.exist(error);
                             should.exist(body);
-                            should.exist(body['Temperature%20Sensor']);
+                            body.should.be.instanceof(Array).and.have.lengthOf(1);
+                            should.exist(body[0]['Temperature%20Sensor']);
                             done();
                         });
                     }

--- a/test/unit/ngsiv2/testConfig.js
+++ b/test/unit/ngsiv2/testConfig.js
@@ -173,7 +173,7 @@ config.ngsi = {
     },
     service: 'smartgondor',
     subservice: '/gardens',
-    providerUrl: 'http://localhost:4041/v1',
+    providerUrl: 'http://localhost:4041/v2',
     deviceRegistrationDuration: 'P1M'
 };
 

--- a/test/unit/ngsiv2/tests.js
+++ b/test/unit/ngsiv2/tests.js
@@ -1,0 +1,4 @@
+require('./registration-test.js');
+require('./active-attributes-test.js');
+require('./passive-attributes-test.js');
+require('./commands-test.js');

--- a/test/unit/passive-attributes-test.js
+++ b/test/unit/passive-attributes-test.js
@@ -201,6 +201,18 @@ describe('Passive attributes test', function() {
                 should.not.exist(error);
                 handleExecuted.should.equal(true);
 
+                should.exist(body);
+                body.contextResponses.should.be.instanceof(Array).and.have.lengthOf(1);
+                var ce = body.contextResponses[0].contextElement;
+                ce.id.should.equal('TestClient:Light');
+                ce.isPattern.should.equal('false');
+                ce.type.should.equal('Light');
+                ce.attributes.should.be.instanceof(Array).and.have.lengthOf(1);
+                var attr = ce['attributes'][0];
+                attr.name.should.equal('LWM2M Server URI');
+                attr.type.should.equal('String');
+                attr.value.should.equal('coap://localhost');
+
                 done();
             });
         });

--- a/test/unit/tests.js
+++ b/test/unit/tests.js
@@ -1,0 +1,6 @@
+require('./registration-test.js');
+require('./update-registration-test.js');
+require('./configuration-test.js');
+require('./active-attributes-test.js');
+require('./passive-attributes-test.js');
+require('./commands-test.js');


### PR DESCRIPTION
This PR migrates the work done by PR #186 by @dcalvoalonso and PR https://github.com/dcalvoalonso/lightweightm2m-iotagent/pull/1 by @fgalan. In particular, it can be checked that:

* First commit ddfcebf has +578 -17 modifications and corresponds to PR #186 with +578 -17 (exact match)
* Second commit 1868a2f has +76 -45 modifications and corresponds to PR https://github.com/dcalvoalonso/lightweightm2m-iotagent/pull/1 with +76 -45
* Third commit 05889e9 is for setting the iotagent-node-lib branch to the one used in https://github.com/telefonicaid/iotagent-node-lib/pull/813

Commits beyond the third one are additional fixes.