### PR TITLE
added UDP protocol to lwm2m port definition on dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,7 +103,7 @@ USER node
 ENV NODE_ENV=production
 
 # Expose Ports - Default to 4041 for NORTH PORT, 5684 for LWM2M PORT
-EXPOSE ${IOTA_NORTH_PORT:-4041} ${LWM2M_PORT:-5684}
+EXPOSE ${IOTA_NORTH_PORT:-4041} ${LWM2M_PORT:-5684}/udp
 
 ENTRYPOINT ["docker/entrypoint.sh"]
 CMD ["-- ", "config.js"]


### PR DESCRIPTION
This PR solves issue #201. 

It was added UDP protocol to port definition on dockerfile. 

netcat -vzu 127.0.0.1 5684 
Connection to 127.0.0.1 5684 port [udp/*] succeeded!
