### PR TITLE
Task/add leshan objects uri list support

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: support to lazy attributes and commands based in NGSIv2 (#104)
+- Fix: support to other lwm2m clients i.e. Leshan java client

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - Fix: support to lazy attributes and commands based in NGSIv2 (#104)
-- Fix: support to other lwm2m clients i.e. Leshan java client
+- Fix: support to lwm2m client that separe object instances using spaces

--- a/lib/lwm2mUtils.js
+++ b/lib/lwm2mUtils.js
@@ -29,11 +29,14 @@
  * @return {Array}              A list of the supported Object URIs.
  */
 function parseObjectUriList(payload) {
-    return payload
-        .replace(/</g, '')
-        .replace(/>/g, '')
-        .replace(/\s/g, '')
-        .split(',');
+    return (
+        payload
+            .replace(/</g, '')
+            .replace(/>/g, '')
+            // Checking master test pass without modifications
+            //        .replace(/\s/g, '')
+            .split(',')
+    );
 }
 
 exports.parseObjectUriList = parseObjectUriList;

--- a/lib/lwm2mUtils.js
+++ b/lib/lwm2mUtils.js
@@ -32,6 +32,7 @@ function parseObjectUriList(payload) {
     return payload
         .replace(/</g, '')
         .replace(/>/g, '')
+        .replace(/\s/g, '')
         .split(',');
 }
 

--- a/lib/lwm2mUtils.js
+++ b/lib/lwm2mUtils.js
@@ -29,14 +29,11 @@
  * @return {Array}              A list of the supported Object URIs.
  */
 function parseObjectUriList(payload) {
-    return (
-        payload
-            .replace(/</g, '')
-            .replace(/>/g, '')
-            // Checking master test pass without modifications
-            //        .replace(/\s/g, '')
-            .split(',')
-    );
+    return payload
+        .replace(/</g, '')
+        .replace(/>/g, '')
+        .replace(/\s/g, '')
+        .split(',');
 }
 
 exports.parseObjectUriList = parseObjectUriList;

--- a/test/unit/lwm2mUtils-test.js
+++ b/test/unit/lwm2mUtils-test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-iotagent-lib
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+'use strict';
+
+var lwm2mUtils = require('./../../lib/lwm2mUtils'),
+    should = require('should'),
+    expectedLwm2mObjects = ['/1/0', '/1/1', '/1/2', '/1/3', '/1/4', '/1/5', '/1/6'];
+
+describe('lwm2mUtils test', function() {
+    describe('When parse objects uri list is called with a comma separated list', function() {
+        it('should should return an array with parsed resource paths', function(done) {
+            var parsedLwM2MObjetcs = lwm2mUtils.parseObjectUriList(expectedLwm2mObjects.join(','));
+            should.equal(JSON.stringify(expectedLwm2mObjects), JSON.stringify(parsedLwM2MObjetcs));
+            done();
+        });
+    });
+
+    describe('When parse objects uri list is called with a comma plus space separated list', function() {
+        it('should should return an array with parsed resource paths', function(done) {
+            var parsedLwM2MObjetcs = lwm2mUtils.parseObjectUriList(expectedLwm2mObjects.join(', '));
+            should.equal(JSON.stringify(expectedLwm2mObjects), JSON.stringify(parsedLwM2MObjetcs));
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Some lwm2m clients like leshan ones separe object instances using spaces. i.e.

**`Node lib client`**
```
POST /rd/<resource_directory> </3/0>,</3/0>,</3/0>
```
**`Leshan client`**
```
POST /rd/<resource_directory>  </3/0>, </3/0>, </3/0>
```
This behaibour makes that lifhtwaightm2m-iotagent can't create observers after device registration because the objects don't match with the definition of the attributes in the config.js specicicatoin.

i.e.
```
" /3/0"  !== "/3/0"
```

This modification remove the spaces from the request body and allow lightweightm2m-iotagent to create the observers.
