### PR TITLE
Bump to Node 10

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Upgrade NodeJS version from 8.16.1 to 10.17.0 in Dockerfile due to Node 8 End-of-Life 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@
 #
 # Modified by: Daniel Calvo - ATOS Research & Innovation
 #
-ARG NODE_VERSION=8.16.1-slim
+ARG NODE_VERSION=10.17.0-slim
 FROM node:${NODE_VERSION}
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=lightweightm2m-iotagent


### PR DESCRIPTION
Node 8 leaves LTS at the end of the year. The default node version should be switched to Node Dubnium for the upcoming December FIWARE 7.8.1 Patch release.