### PR TITLE
Update .travis.yml (fix orion 2.4.0 instead of upper version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
 
       before_install:
         - docker pull fiware/orion:latest
-        - docker run -d --net host -l orion fiware/orion:latest
+        - docker run -d --net host -l orion fiware/orion:2.4.0
 
       before_script:
         - npm run lint
@@ -37,7 +37,7 @@ jobs:
 
       before_install:
         - docker pull fiware/orion:latest
-        - docker run -d --net host -l orion fiware/orion:latest
+        - docker run -d --net host -l orion fiware/orion:2.4.0
 
       before_script:
         - npm run lint


### PR DESCRIPTION
This error occurs with orion 2.4.1 and latest
```
time=2020-09-28T09:39:50.273Z | lvl=ERROR | corr=n/a | trans=n/a | op=IoTAgentNGSI.DeviceService | msg=Registration error connecting to the Context Broker: 400
time=2020-09-28T09:39:50.273Z | lvl=DEBUG | corr=n/a | trans=n/a | op=LWM2MLib.Registration | msg=Registration request ended up in error [BAD_REQUEST] with code [400]
time=2020-09-28T09:39:50.274Z | lvl=ERROR | corr=n/a | trans=n/a | op=LWM2MLib.Client | msg=Registration failed with code: 4.00
```