### PR TITLE
Replace checkNgsi2 with isCurrentNgsi

### DIFF
--- a/lib/ngsiHandlers.js
+++ b/lib/ngsiHandlers.js
@@ -159,7 +159,7 @@ function ngsiUpdateHandler(id, type, service, subservice, attributes, callback) 
         async.map(attributes, async.apply(writeAttribute, ngsiDevice, lwm2mDevice), innerCallback);
     }
 
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         for (let i = 0; i < attributes.length; i++) {
             attributes[i].name = decodeURI(attributes[i].name);
         }
@@ -319,7 +319,7 @@ function ngsiQueryHandler(id, type, service, subservice, attributes, callback) {
     }
 
     function createContextElement(device, attributeValues, callback) {
-        if (iotAgentLib.configModule.checkNgsi2()) {
+        if (iotAgentLib.configModule.isCurrentNgsi()) {
             createContextElementNgsi2(device, attributeValues, callback);
         } else {
             createContextElementNgsi1(device, attributeValues, callback);
@@ -337,7 +337,7 @@ function ngsiQueryHandler(id, type, service, subservice, attributes, callback) {
         name = id;
     }
 
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         for (let i = 0; i < attributes.length; i++) {
             attributes[i] = decodeURI(attributes[i]);
         }

--- a/lib/ngsiUtils.js
+++ b/lib/ngsiUtils.js
@@ -116,7 +116,7 @@ function updateEntityNgsi2(host, port, service, subservice, name, type, attribut
  * @param {Array} attributes        List of attributes to retrieve, along with their types and values.
  */
 function updateEntity(host, port, service, subservice, name, type, attributes, callback) {
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         updateEntityNgsi2(host, port, service, subservice, name, type, attributes, callback);
     } else {
         updateEntityNgsi1(host, port, service, subservice, name, type, attributes, callback);
@@ -215,7 +215,7 @@ function queryEntityNgsi1(host, port, service, subservice, id, type, attributes,
  * @param {Array} attributes        List of attributes to retrieve.
  */
 function queryEntity(host, port, service, subservice, id, type, attributes, callback) {
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         queryEntityNgsi2(host, port, service, subservice, id, type, attributes, callback);
     } else {
         queryEntityNgsi1(host, port, service, subservice, id, type, attributes, callback);

--- a/lib/services/lwm2mHandlers/commonLwm2m.js
+++ b/lib/services/lwm2mHandlers/commonLwm2m.js
@@ -120,7 +120,7 @@ function observeActiveAttributes(payload, registeredDevice, callback) {
 
         let attName;
 
-        if (iotAgentLib.configModule.checkNgsi2()) {
+        if (iotAgentLib.configModule.isCurrentNgsi()) {
             attName = decodeURI(activeAttributes[i].name);
         } else {
             attName = activeAttributes[i].name;

--- a/lib/services/lwm2mHandlers/registration.js
+++ b/lib/services/lwm2mHandlers/registration.js
@@ -189,7 +189,7 @@ function addUnsupportedAttributes(payload, configuration, deviceInformation, cal
             }
             // In NGSIv2, spaces cannot be used in attributes' names. Therefore, we use percent-enconding.
             // %23 is the URL encode char for '#', as that char is forbidden by the NGSIv2 spec in attribute names
-            if (iotAgentLib.configModule.checkNgsi2()) {
+            if (iotAgentLib.configModule.isCurrentNgsi()) {
                 previous.push({
                     name: encodeURI(omaRegistry[value.objectType].name) + '%23' + value.objectInstance,
                     type: 'string'
@@ -223,7 +223,7 @@ function addUnsupportedAttributes(payload, configuration, deviceInformation, cal
     }
 
     deviceInformation.lazy = deviceInformation.lazy.concat(newAttributes);
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         for (const att in deviceInformation.lazy) {
             deviceInformation.lazy[att].name = encodeURI(deviceInformation.lazy[att].name);
         }


### PR DESCRIPTION
Related https://github.com/telefonicaid/iotagent-node-lib/issues/963

Note: the `isCurrentNgsi()` can be removed once NGSI-v1 is dropped.