### PR TITLE
Add graceful shutdown

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,4 @@
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
 - Remove: NGSI-v1 specific behaviours (iotagent-node-lib#966)
-- FIX: Add graceful shutdown listening to SIGINT (#606)
+- FIX: Add graceful shutdown listening to SIGINT (#258)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
 - Remove: NGSI-v1 specific behaviours (iotagent-node-lib#966)
+- FIX: Add graceful shutdown listening to SIGINT (#606)

--- a/docs/userGuide.md
+++ b/docs/userGuide.md
@@ -187,6 +187,15 @@ npm run
 
 The following sections show the available options in detail.
 
+### Start
+
+Runs a local version of the IoT Agent
+
+```bash
+# Use git-bash on Windows
+npm start
+```
+
 ### Testing
 
 [Mocha](https://mochajs.org/) Test Runner + [Should.js](https://shouldjs.github.io/) Assertion Library.

--- a/lib/iotAgentLwm2m.js
+++ b/lib/iotAgentLwm2m.js
@@ -99,7 +99,7 @@ function stop(callback) {
  *
  */
 function handleShutdown(signal) {
-    config.getLogger().fatal(context, 'Received %s, starting shutdown processs', signal);
+    config.getLogger().info(context, 'Received %s, starting shutdown processs', signal);
     stop((err) => {
         if (err) {
             config.getLogger().error(context, err);

--- a/lib/iotAgentLwm2m.js
+++ b/lib/iotAgentLwm2m.js
@@ -72,7 +72,7 @@ function start(localConfig, callback) {
     ngsiHandlers.init(config);
     commons.init(config);
 
-    async.series([apply(lwm2mLib.start, localConfig.lwm2m), apply(iotAgentLib.activate, localConfig.ngsi)], function(
+    async.series([apply(lwm2mLib.start, localConfig.lwm2m), apply(iotAgentLib.activate, localConfig.ngsi)], function (
         error,
         results
     ) {
@@ -93,6 +93,25 @@ function stop(callback) {
     logger.info(context, 'Stopping IoT Agent');
     async.series([apply(lwm2mLib.stop, serverInfo), iotAgentLib.deactivate], callback);
 }
+
+/**
+ * Shuts down the IoT Agent in a graceful manner
+ *
+ */
+function handleShutdown(signal) {
+    config.getLogger().fatal(context, 'Received %s, starting shutdown processs', signal);
+    stop((err) => {
+        if (err) {
+            config.getLogger().error(context, err);
+            return process.exit(1);
+        }
+        return process.exit(0);
+    });
+}
+
+process.on('SIGINT', handleShutdown);
+process.on('SIGTERM', handleShutdown);
+process.on('SIGHUP', handleShutdown);
 
 exports.start = start;
 exports.stop = stop;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint:text": "textlint 'README.md' 'docs/*.md' 'docs/**/*.md'",
     "prettier": "prettier --config .prettierrc.json --write '**/**/**/*.js' '**/**/*.js' '**/*.js' '*.js'",
     "prettier:text": "prettier 'README.md' 'docs/*.md' 'docs/**/*.md' --no-config --tab-width 4 --print-width 120 --write --prose-wrap always",
+    "start": "node ./bin/lwm2mAgent.js",
     "test": "nyc --reporter=text mocha --recursive 'test/**/*.js' --reporter spec --timeout 5000 --ui bdd --exit --color true",
     "test:coverage": "nyc --reporter=lcov mocha -- --recursive 'test/**/*.js' --reporter spec --timeout 5000 --ui bdd --exit --color true",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",


### PR DESCRIPTION
When a shutdown signal is sent, we need to do graceful shutdown out of Node.js and Express to avoid side effects
like finishing active requests before closing server, clean up resources, db connections etc.

see: https://stackfame.com/node-express-graceful-shutdown