### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
 - Remove: NGSI-v1 specific behaviours (iotagent-node-lib#966)
 - FIX: Add graceful shutdown listening to SIGINT (#258)
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "cheerio": "1.0.0-rc.2",
     "xmldom": "0.1.27",
     "logops": "2.1.2",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
-    "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "lwm2m-node-lib": "https://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },
   "devDependencies": {
     "coveralls": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "underscore": "1.12.1",
     "cheerio": "1.0.0-rc.2",
     "xmldom": "0.1.27",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "lwm2m-node-lib": "git://github.com/telefonicaid/lwm2m-node-lib.git#master"
   },


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/
